### PR TITLE
feat: separate display names of key fields from usages in TM name

### DIFF
--- a/internal/app/cli/common.go
+++ b/internal/app/cli/common.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/wot-oss/tmc/internal/model"
 	"github.com/wot-oss/tmc/internal/repos"
@@ -29,32 +28,9 @@ type FilterFlags struct {
 	Search             string
 }
 
-func (ff *FilterFlags) IsSet() bool {
-	return ff.FilterAuthor != "" || ff.FilterManufacturer != "" || ff.FilterMpn != "" || ff.Search != ""
-}
-
 func CreateSearchParamsFromCLI(flags FilterFlags, name string) *model.SearchParams {
-	var search *model.SearchParams
-	if flags.IsSet() || name != "" {
-		search = &model.SearchParams{}
-		if flags.FilterAuthor != "" {
-			search.Author = strings.Split(flags.FilterAuthor, DefaultListSeparator)
-		}
-		if flags.FilterManufacturer != "" {
-			search.Manufacturer = strings.Split(flags.FilterManufacturer, DefaultListSeparator)
-		}
-		if flags.FilterMpn != "" {
-			search.Mpn = strings.Split(flags.FilterMpn, DefaultListSeparator)
-		}
-		if flags.Search != "" {
-			search.Query = flags.Search
-		}
-		if name != "" {
-			search.Name = name
-		}
-		search.Options.NameFilterType = model.PrefixMatch
-	}
-	return search
+	return model.ToSearchParams(&flags.FilterAuthor, &flags.FilterManufacturer, &flags.FilterMpn, &name, &flags.Search,
+		&model.SearchOptions{NameFilterType: model.PrefixMatch})
 }
 
 func printErrs(hdr string, errs []*repos.RepoAccessError) {

--- a/internal/app/cli/common_test.go
+++ b/internal/app/cli/common_test.go
@@ -15,29 +15,6 @@ func resetSearchFlags(flags *FilterFlags) {
 	flags.Search = ""
 }
 
-func TestFilterFlagsSet(t *testing.T) {
-	underTest := FilterFlags{}
-
-	resetSearchFlags(&underTest)
-	underTest.FilterAuthor = "some value"
-	assert.True(t, underTest.IsSet())
-
-	resetSearchFlags(&underTest)
-	underTest.FilterManufacturer = "some value"
-	assert.True(t, underTest.IsSet())
-
-	resetSearchFlags(&underTest)
-	underTest.FilterMpn = "some value"
-	assert.True(t, underTest.IsSet())
-
-	resetSearchFlags(&underTest)
-	underTest.Search = "some value"
-	assert.True(t, underTest.IsSet())
-
-	resetSearchFlags(&underTest)
-	assert.False(t, underTest.IsSet())
-}
-
 func TestConvertSearchParams(t *testing.T) {
 
 	// given: no filter params set via CLI flags

--- a/internal/app/cli/pull_test.go
+++ b/internal/app/cli/pull_test.go
@@ -84,15 +84,14 @@ func TestPullExecutor_Pull(t *testing.T) {
 	tmContent1 := []byte("some TM content 1")
 	tmContent2 := []byte("some TM content 2")
 	tmContent3 := []byte("some TM content 3")
-	search := &model.SearchParams{}
-
-	r.On("List", mock.Anything, search).Return(listResult, nil).Once()
+	var sp *model.SearchParams
+	r.On("List", mock.Anything, sp).Return(listResult, nil).Once()
 	r.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 	r.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 	r.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
 
 	// when: pulling from repo
-	err = Pull(context.Background(), model.NewRepoSpec("r1"), search, tempDir, false)
+	err = Pull(context.Background(), model.NewRepoSpec("r1"), nil, tempDir, false)
 	// then: there is no error
 	assert.NoError(t, err)
 	// and then: the pulled ThingModels are written to the output path
@@ -146,18 +145,17 @@ func TestPullExecutor_Pull_InvalidOutputPath(t *testing.T) {
 	r := mocks.NewRepo(t)
 	rMocks.MockReposGet(t, func(s model.RepoSpec) (repos.Repo, error) { return r, nil })
 	r.On("List", mock.Anything).Return(listResult, nil).Maybe()
-	search := &model.SearchParams{}
 
 	t.Run("with empty output path", func(t *testing.T) {
 		// given: an empty output path
 		outputPath := ""
 		// when: pulling from repo
-		err := Pull(context.Background(), model.NewRepoSpec("r1"), search, outputPath, false)
+		err := Pull(context.Background(), model.NewRepoSpec("r1"), nil, outputPath, false)
 		// then: there is an error
 		assert.Error(t, err)
 		// and then: there are no calls on Repo
-		r.AssertNotCalled(t, "List", mock.Anything)
-		r.AssertNotCalled(t, "Fetch", mock.Anything)
+		r.AssertNotCalled(t, "List", mock.Anything, mock.Anything)
+		r.AssertNotCalled(t, "Fetch", mock.Anything, mock.Anything)
 	})
 
 	t.Run("with output path is a file", func(t *testing.T) {
@@ -169,12 +167,12 @@ func TestPullExecutor_Pull_InvalidOutputPath(t *testing.T) {
 		outputPath := filepath.Join(tempDir, "foo.bar")
 		_ = os.WriteFile(outputPath, []byte("foobar"), 0660)
 		// when: pulling from repo
-		err = Pull(context.Background(), model.NewRepoSpec("r1"), search, outputPath, false)
+		err = Pull(context.Background(), model.NewRepoSpec("r1"), nil, outputPath, false)
 		// then: there is an error
 		assert.Error(t, err)
 		// and then: there are no calls on Repo
-		r.AssertNotCalled(t, "List", mock.Anything)
-		r.AssertNotCalled(t, "Fetch", mock.Anything)
+		r.AssertNotCalled(t, "List", mock.Anything, mock.Anything)
+		r.AssertNotCalled(t, "Fetch", mock.Anything, mock.Anything)
 	})
 }
 

--- a/internal/app/cli/push_test.go
+++ b/internal/app/cli/push_test.go
@@ -23,7 +23,7 @@ func TestPushExecutor_Push(t *testing.T) {
 
 		now := func() time.Time { return time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC) }
 		e := NewPushExecutor(now)
-		id := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json"
+		id := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
 		r.On("Index", mock.Anything, id).Return(nil)
@@ -44,14 +44,14 @@ func TestPushExecutor_Push(t *testing.T) {
 
 	t.Run("push when repo has the same TM", func(t *testing.T) {
 
-		tmid2 := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231111123243-3f779458e453.tm.json")
+		tmid2 := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231111123243-98b3fbd291f4.tm.json")
 
 		now := func() time.Time {
 			return time.Date(2023, time.November, 11, 12, 32, 43, 0, time.UTC)
 		}
 		e := NewPushExecutor(now)
 		r.On("Push", mock.Anything, tmid2, mock.Anything).Return(&repos.ErrTMIDConflict{Type: repos.IdConflictSameContent,
-			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json"})
+			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"})
 		res, err := e.Push(context.Background(), "../../../test/data/push/omnilamp-versioned.json", model.NewRepoSpec("repo"), "", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 1)
@@ -60,7 +60,7 @@ func TestPushExecutor_Push(t *testing.T) {
 
 	t.Run("push fails", func(t *testing.T) {
 
-		tmid3 := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20230811123243-3f779458e453.tm.json")
+		tmid3 := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20230811123243-98b3fbd291f4.tm.json")
 		now := func() time.Time {
 			return time.Date(2023, time.August, 11, 12, 32, 43, 0, time.UTC)
 		}
@@ -75,7 +75,7 @@ func TestPushExecutor_Push(t *testing.T) {
 	t.Run("push with optPath", func(t *testing.T) {
 		now := func() time.Time { return time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC) }
 		e := NewPushExecutor(now)
-		id := "omnicorp-tm-department/omnicorp/omnilamp/a/b/c/v3.2.1-20231110123243-3f779458e453.tm.json"
+		id := "omnicorp-tm-department/omnicorp/omnilamp/a/b/c/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
 		r.On("Index", mock.Anything, id).Return(nil)
@@ -94,19 +94,19 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 	t.Run("push directory", func(t *testing.T) {
 		clk := testutils.NewTestClock(time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC), time.Second)
 		e := NewPushExecutor(clk.Now)
-		tmid := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json")
+		tmid := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json")
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-80424c65e4e6.tm.json")
+		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json")
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123245-3f779458e453.tm.json")
+		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123245-98b3fbd291f4.tm.json")
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(&repos.ErrTMIDConflict{Type: repos.IdConflictSameContent,
-			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json"})
-		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123246-80424c65e4e6.tm.json")
+			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"})
+		tmid = model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123246-575dfac219e2.tm.json")
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(&repos.ErrTMIDConflict{Type: repos.IdConflictSameContent,
-			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-80424c65e4e6.tm.json"})
+			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json"})
 		r.On("Index", mock.Anything,
-			"omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json",
-			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-80424c65e4e6.tm.json").Return(nil)
+			"omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json",
+			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return(nil)
 
 		res, err := e.Push(context.Background(), "../../../test/data/push", model.NewRepoSpec("repo"), "", false)
 		assert.NoError(t, err)
@@ -121,16 +121,16 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 	t.Run("push directory with optPath", func(t *testing.T) {
 		clk := testutils.NewTestClock(time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC), time.Second)
 		e := NewPushExecutor(clk.Now)
-		id1 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v3.2.1-20231110123243-3f779458e453.tm.json"
+		id1 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id1)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id2 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v0.0.0-20231110123244-80424c65e4e6.tm.json"
+		id2 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v0.0.0-20231110123244-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id2)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id3 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v3.2.1-20231110123245-3f779458e453.tm.json"
+		id3 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v3.2.1-20231110123245-98b3fbd291f4.tm.json"
 		tmid = model.MustParseTMID(id3)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id4 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v0.0.0-20231110123246-80424c65e4e6.tm.json"
+		id4 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v0.0.0-20231110123246-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id4)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
 		r.On("Index", mock.Anything, id1, id2, id3, id4).Return(nil)
@@ -147,16 +147,16 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 	t.Run("push directory with optTree", func(t *testing.T) {
 		clk := testutils.NewTestClock(time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC), time.Second)
 		e := NewPushExecutor(clk.Now)
-		id1 := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-3f779458e453.tm.json"
+		id1 := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id1)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id2 := "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-80424c65e4e6.tm.json"
+		id2 := "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id2)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id3 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20231110123245-3f779458e453.tm.json"
+		id3 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20231110123245-98b3fbd291f4.tm.json"
 		tmid = model.MustParseTMID(id3)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
-		id4 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20231110123246-80424c65e4e6.tm.json"
+		id4 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20231110123246-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id4)
 		r.On("Push", mock.Anything, tmid, mock.Anything).Return(nil)
 		r.On("Index", mock.Anything, id1, id2, id3, id4).Return(nil)

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/wot-oss/tmc/internal/app/http/server"
@@ -224,27 +223,8 @@ func convertParams(params any) *model.SearchParams {
 		search = mpnsParams.Search
 	}
 
-	var searchParams model.SearchParams
-	if filterAuthor != nil || filterManufacturer != nil || filterMpn != nil || filterName != nil || search != nil {
-		searchParams = model.SearchParams{}
-		if filterAuthor != nil {
-			searchParams.Author = strings.Split(*filterAuthor, ",")
-		}
-		if filterManufacturer != nil {
-			searchParams.Manufacturer = strings.Split(*filterManufacturer, ",")
-		}
-		if filterMpn != nil {
-			searchParams.Mpn = strings.Split(*filterMpn, ",")
-		}
-		if filterName != nil {
-			searchParams.Name = *filterName
-			searchParams.Options.NameFilterType = model.PrefixMatch
-		}
-		if search != nil {
-			searchParams.Query = *search
-		}
-	}
-	return &searchParams
+	return model.ToSearchParams(filterAuthor, filterManufacturer, filterMpn, filterName, search,
+		&model.SearchOptions{NameFilterType: model.PrefixMatch})
 }
 
 func toInventoryResponse(ctx context.Context, res model.SearchResult) server.InventoryResponse {

--- a/internal/app/http/service_test.go
+++ b/internal/app/http/service_test.go
@@ -164,10 +164,11 @@ func Test_ListInventory(t *testing.T) {
 	t.Run("list all", func(t *testing.T) {
 		// given: repo having some inventory entries
 		r := mocks.NewRepo(t)
-		r.On("List", mock.Anything, &model.SearchParams{Author: []string{"a-corp", "b-corp"}}).Return(listResult, nil).Once()
+		searchParams := &model.SearchParams{Author: []string{"a-corp", "b-corp"}}
+		r.On("List", mock.Anything, searchParams).Return(listResult, nil).Once()
 		rMocks.MockReposAll(t, rMocks.CreateMockAllFunction(nil, r))
 		// when: list all
-		res, err := underTest.ListInventory(context.Background(), &model.SearchParams{Author: []string{"a-corp", "b-corp"}})
+		res, err := underTest.ListInventory(context.Background(), searchParams)
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the search result is returned
@@ -177,12 +178,13 @@ func Test_ListInventory(t *testing.T) {
 		// given: repo having some inventory entries
 		r := mocks.NewRepo(t)
 		r2 := mocks.NewRepo(t)
-		r.On("List", mock.Anything, &model.SearchParams{}).Return(listResult, nil).Once()
-		r2.On("List", mock.Anything, &model.SearchParams{}).Return(model.SearchResult{}, errors.New("unexpected")).Once()
+		var sp *model.SearchParams
+		r.On("List", mock.Anything, sp).Return(listResult, nil).Once()
+		r2.On("List", mock.Anything, sp).Return(model.SearchResult{}, errors.New("unexpected")).Once()
 		r2.On("Spec").Return(model.NewRepoSpec("r2")).Once()
 		rMocks.MockReposAll(t, rMocks.CreateMockAllFunction(nil, r, r2))
 		// when: list all
-		res, err := underTest.ListInventory(context.Background(), &model.SearchParams{})
+		res, err := underTest.ListInventory(context.Background(), sp)
 		// then: there is an error of type repos.RepoAccessError
 		var aErr *repos.RepoAccessError
 		assert.ErrorAs(t, err, &aErr)

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -13,11 +13,12 @@ import (
 )
 
 func TestListCommand_List(t *testing.T) {
+	params := &model.SearchParams{Query: "omnicorp"}
 	t.Run("merged", func(t *testing.T) {
 		r1 := mocks.NewRepo(t)
 		r2 := mocks.NewRepo(t)
 		rMocks.MockReposAll(t, rMocks.CreateMockAllFunction(nil, r1, r2))
-		r1.On("List", mock.Anything, &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+		r1.On("List", mock.Anything, params).Return(model.SearchResult{
 			Entries: []model.FoundEntry{
 				{
 					Name:         "omnicorp/senseall",
@@ -33,7 +34,7 @@ func TestListCommand_List(t *testing.T) {
 				},
 			},
 		}, nil)
-		r2.On("List", mock.Anything, &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+		r2.On("List", mock.Anything, params).Return(model.SearchResult{
 			Entries: []model.FoundEntry{
 				{
 					Name:         "omnicorp/senseall",
@@ -50,7 +51,7 @@ func TestListCommand_List(t *testing.T) {
 			},
 		}, nil)
 
-		res, err, _ := List(context.Background(), model.EmptySpec, &model.SearchParams{Query: "omnicorp"})
+		res, err, _ := List(context.Background(), model.EmptySpec, params)
 
 		assert.NoError(t, err)
 		assert.Len(t, res.Entries, 3)
@@ -63,7 +64,7 @@ func TestListCommand_List(t *testing.T) {
 		r2 := mocks.NewRepo(t)
 		r2.On("Spec").Return(model.NewRepoSpec("r2"))
 		rMocks.MockReposAll(t, rMocks.CreateMockAllFunction(nil, r1, r2))
-		r1.On("List", mock.Anything, &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+		r1.On("List", mock.Anything, params).Return(model.SearchResult{
 			Entries: []model.FoundEntry{
 				{
 					Name:         "omnicorp/senseall",
@@ -79,9 +80,9 @@ func TestListCommand_List(t *testing.T) {
 				},
 			},
 		}, nil)
-		r2.On("List", mock.Anything, &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{}, errors.New("unexpected error"))
+		r2.On("List", mock.Anything, params).Return(model.SearchResult{}, errors.New("unexpected error"))
 
-		res, err, errs := List(context.Background(), model.EmptySpec, &model.SearchParams{Query: "omnicorp"})
+		res, err, errs := List(context.Background(), model.EmptySpec, params)
 
 		assert.NoError(t, err)
 		if assert.Len(t, errs, 1) {

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -78,11 +78,6 @@ func prepareToImport(now Now, tm *model.ThingModel, raw []byte, optPath string) 
 	var intermediate = make([]byte, len(raw))
 	copy(intermediate, raw)
 
-	intermediate, err := replaceKeysWithSanitized(intermediate, tm)
-	if err != nil {
-		return nil, model.TMID{}, err
-	}
-
 	// see if there's an id in the file that needs to be preserved
 	value, dataType, _, err := jsonparser.Get(intermediate, "id")
 	if err != nil && dataType != jsonparser.NotExist {
@@ -123,21 +118,6 @@ func prepareToImport(now Now, tm *model.ThingModel, raw []byte, optPath string) 
 	return final, finalId, nil
 }
 
-func replaceKeysWithSanitized(bytes []byte, tm *model.ThingModel) ([]byte, error) {
-	authorString, _ := json.Marshal(tm.Author.Name)
-	bytes, err := jsonparser.Set(bytes, authorString, "schema:author", "schema:name")
-	if err != nil {
-		return bytes, err
-	}
-	manufString, _ := json.Marshal(tm.Manufacturer.Name)
-	bytes, err = jsonparser.Set(bytes, manufString, "schema:manufacturer", "schema:name")
-	if err != nil {
-		return bytes, err
-	}
-	mpnString, _ := json.Marshal(tm.Mpn)
-	bytes, err = jsonparser.Set(bytes, mpnString, "schema:mpn")
-	return bytes, err
-}
 func moveIdToOriginalLink(raw []byte, id string) []byte {
 	linksValue, dataType, _, err := jsonparser.Get(raw, "links")
 	if err != nil && dataType != jsonparser.NotExist {

--- a/internal/commands/push_test.go
+++ b/internal/commands/push_test.go
@@ -127,7 +127,7 @@ func TestPrepareToImport(t *testing.T) {
 		}, []byte("{\r\n\"title\":\"test\"\r\n}"), "opt/dir")
 		assert.NoError(t, err)
 		assert.False(t, bytes.Contains(b, []byte{'\r'})) // make sure line endings were normalized
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-35177eefa2bf.tm.json")))
+		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-7ae21a619c71.tm.json")))
 	})
 	t.Run("too long name", func(t *testing.T) {
 		_, _, err := prepareToImport(now, &model.ThingModel{
@@ -147,7 +147,7 @@ func TestPrepareToImport(t *testing.T) {
 		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"foreign-id\"}"), "opt/dir")
 		assert.NoError(t, err)
 		assert.True(t, bytes.Contains(b, []byte("\"href\":\"foreign-id\"")))
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-b353ae119982.tm.json")))
+		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-e7dac5728be6.tm.json")))
 	})
 	t.Run("our string id in original/correct hash", func(t *testing.T) {
 		b, _, err := prepareToImport(now, &model.ThingModel{
@@ -155,10 +155,10 @@ func TestPrepareToImport(t *testing.T) {
 			Mpn:          "senseall",
 			Author:       model.SchemaAuthor{Name: "author"},
 			Version:      model.Version{Model: "v3.2.1"},
-		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"author/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7a42c7450082.tm.json\"}"), "opt/dir")
+		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"author/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7ae21a619c71.tm.json\"}"), "opt/dir")
 		assert.NoError(t, err)
 		// no change in id
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7a42c7450082.tm.json")))
+		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7ae21a619c71.tm.json")))
 	})
 	t.Run("our string id in original/incorrect author", func(t *testing.T) {
 		b, _, err := prepareToImport(now, &model.ThingModel{
@@ -166,10 +166,10 @@ func TestPrepareToImport(t *testing.T) {
 			Mpn:          "senseall",
 			Author:       model.SchemaAuthor{Name: "author"},
 			Version:      model.Version{Model: "v3.2.1"},
-		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"publisher/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7a42c7450082.tm.json\"}"), "opt/dir")
+		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"publisher/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-7ae21a619c71.tm.json\"}"), "opt/dir")
 		assert.NoError(t, err)
 		// new generated id
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-7a42c7450082.tm.json")))
+		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-7ae21a619c71.tm.json")))
 	})
 	t.Run("our string id in original/incorrect hash", func(t *testing.T) {
 		b, _, err := prepareToImport(now, &model.ThingModel{
@@ -180,22 +180,8 @@ func TestPrepareToImport(t *testing.T) {
 		}, []byte("{\r\n\"title\":\"test\"\r\n,\"id\":\"author/omnicorp/senseall/opt/dir/v3.2.1-20221010123243-863e9f0f950a.tm.json\"}"), "opt/dir")
 		assert.NoError(t, err)
 		// new generated id
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-7a42c7450082.tm.json")))
+		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir/v3.2.1-20231110123243-7ae21a619c71.tm.json")))
 	})
-	t.Run("replaces keys with sanitized", func(t *testing.T) {
-		b, _, err := prepareToImport(now, &model.ThingModel{
-			Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
-			Mpn:          "senseall",
-			Author:       model.SchemaAuthor{Name: "author"},
-			Version:      model.Version{Model: "v3.2.1"},
-		}, []byte("{\r\n\"title\":\"test\"\r\n,\"schema:manufacturer\":{\n\"schema:name\":\"OMNICORP\"\n},\n\"schema:mpn\":\"SenseAll\",\n\"schema:author\":{\n\"schema:name\":\"Author\"\n}}"), "Opt/Dir")
-		assert.NoError(t, err)
-		assert.True(t, bytes.Contains(b, []byte("\"schema:name\":\"omnicorp\"")))
-		assert.True(t, bytes.Contains(b, []byte("\"schema:name\":\"author\"")))
-		assert.True(t, bytes.Contains(b, []byte("\"schema:mpn\":\"senseall\"")))
-		assert.True(t, bytes.Contains(b, []byte("author/omnicorp/senseall/opt/dir")))
-	})
-
 }
 
 func TestPushToRepoUnversioned(t *testing.T) {

--- a/internal/model/id_test.go
+++ b/internal/model/id_test.go
@@ -95,3 +95,13 @@ func TestTMID_String(t *testing.T) {
 
 	assert.Equal(t, "manufacturer/manufacturer/mpn/byfirmware/v1/v1.2.3-20241243052343-ab1234567890.tm.json", id2.String())
 }
+
+func TestNewTMID_SanitizesNameParts(t *testing.T) {
+	id := NewTMID("aut/hor", "MAN&UFACTURER", "mpn!", "by_firmware/v1",
+		TMVersion{
+			Base:      semver.MustParse("v1.2.3"),
+			Timestamp: "20241243052343",
+			Hash:      "ab1234567890",
+		})
+	assert.Equal(t, "aut-hor/man-ufacturer/mpn/by-firmware/v1", id.Name)
+}

--- a/internal/model/id_test.go
+++ b/internal/model/id_test.go
@@ -12,20 +12,14 @@ func TestParseId(t *testing.T) {
 	id, err := ParseTMID(i1)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "author", id.Author)
-	assert.Equal(t, "manufacturer", id.Manufacturer)
-	assert.Equal(t, "mpn", id.Mpn)
-	assert.Equal(t, "", id.OptionalPath)
+	assert.Equal(t, "author/manufacturer/mpn", id.Name)
 	assert.Equal(t, "v1.2.3-pre1", id.Version.Base.Original())
 
 	i2 := "author/manufacturer/mpn/byfirmware/v1/v1.2.3-pre1-20231109150513-e86784632bf6.tm.json"
 	id, err = ParseTMID(i2)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "author", id.Author)
-	assert.Equal(t, "manufacturer", id.Manufacturer)
-	assert.Equal(t, "mpn", id.Mpn)
-	assert.Equal(t, "byfirmware/v1", id.OptionalPath)
+	assert.Equal(t, "author/manufacturer/mpn/byfirmware/v1", id.Name)
 	assert.Equal(t, "v1.2.3-pre1", id.Version.Base.Original())
 
 	ids := []string{
@@ -38,33 +32,6 @@ func TestParseId(t *testing.T) {
 	}
 }
 
-func TestTMID_AssertValidFor(t *testing.T) {
-	tm := &ThingModel{
-		Manufacturer: SchemaManufacturer{"manufacturer"},
-		Mpn:          "mpn",
-		Author:       SchemaAuthor{"author"},
-		Version:      Version{"1.2.3"},
-	}
-	ids := []string{
-		"authr/manufacturer/mpn/v1.2.3-20231109150513-e86784632bf6.tm.json",
-		"author/manuf/mpn/v1.2.3-20231109150513-e86784632bf6.tm.json",
-		"author/manufacturer/mpn2/v1.2.3-20231109150513-e86784632bf6.tm.json",
-	}
-	for i, v := range ids {
-		id, err := ParseTMID(v)
-		assert.NoError(t, err)
-		err = id.AssertValidFor(tm)
-		assert.ErrorIs(t, err, ErrInvalidId, "incorrect error at %d", i)
-	}
-
-	i1 := "author/manufacturer/mpn/v1.2.3-20231109150513-e86784632bf6.tm.json"
-	id, err := ParseTMID(i1)
-	assert.NoError(t, err)
-	tm.Version.Model = "v1.3"
-	err = id.AssertValidFor(tm)
-	assert.ErrorIs(t, err, ErrVersionDiffers)
-
-}
 func TestParseTMVersion(t *testing.T) {
 	v1 := "v1.2.3-pre1-20231109150513-e86784632bf6"
 	tv1, err := ParseTMVersion(v1)
@@ -110,31 +77,21 @@ func TestTMVersionFromOriginal(t *testing.T) {
 }
 
 func TestTMID_String(t *testing.T) {
-	id := TMID{
-		OptionalPath: "byfirmware/v1",
-		Author:       "author",
-		Manufacturer: "manufacturer",
-		Mpn:          "mpn",
-		Version: TMVersion{
+	id := NewTMID("author", "manufacturer", "mpn", "byfirmware/v1",
+		TMVersion{
 			Base:      semver.MustParse("v1.2.3"),
 			Timestamp: "20241243052343",
 			Hash:      "ab1234567890",
-		},
-	}
+		})
 
 	assert.Equal(t, "author/manufacturer/mpn/byfirmware/v1/v1.2.3-20241243052343-ab1234567890.tm.json", id.String())
 
-	id2 := TMID{
-		OptionalPath: "byfirmware/v1",
-		Author:       "manufacturer",
-		Manufacturer: "manufacturer",
-		Mpn:          "mpn",
-		Version: TMVersion{
+	id2 := NewTMID("manufacturer", "manufacturer", "mpn", "byfirmware/v1",
+		TMVersion{
 			Base:      semver.MustParse("v1.2.3"),
 			Timestamp: "20241243052343",
 			Hash:      "ab1234567890",
-		},
-	}
+		})
 
 	assert.Equal(t, "manufacturer/manufacturer/mpn/byfirmware/v1/v1.2.3-20241243052343-ab1234567890.tm.json", id2.String())
 }

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -35,6 +35,9 @@ func (e *IndexEntry) MatchesSearchText(searchQuery string) bool {
 	if strings.Contains(utils.ToTrimmedLower(e.Name), searchQuery) {
 		return true
 	}
+	if strings.Contains(utils.ToTrimmedLower(e.Author.Name), searchQuery) {
+		return true
+	}
 	if strings.Contains(utils.ToTrimmedLower(e.Manufacturer.Name), searchQuery) {
 		return true
 	}
@@ -69,6 +72,7 @@ func (idx *Index) Filter(search *SearchParams) {
 	if search == nil {
 		return
 	}
+	search.Sanitize()
 	idx.Data = slices.DeleteFunc(idx.Data, func(entry *IndexEntry) bool {
 		if !entry.MatchesSearchText(search.Query) {
 			return true
@@ -120,7 +124,7 @@ func matchesFilter(acceptedValues []string, value string) bool {
 	if len(acceptedValues) == 0 {
 		return true
 	}
-	return slices.Contains(acceptedValues, value)
+	return slices.Contains(acceptedValues, utils.SanitizeName(value))
 }
 
 // findByName searches by name and returns a pointer to the IndexEntry if found
@@ -145,9 +149,9 @@ func (idx *Index) Insert(ctm *ThingModel) (TMID, error) {
 	if idxEntry == nil {
 		idxEntry = &IndexEntry{
 			Name:         tmid.Name,
-			Manufacturer: SchemaManufacturer{Name: tmid.Manufacturer},
-			Mpn:          tmid.Mpn,
-			Author:       SchemaAuthor{Name: tmid.Author},
+			Manufacturer: SchemaManufacturer{Name: ctm.Manufacturer.Name},
+			Mpn:          ctm.Mpn,
+			Author:       SchemaAuthor{Name: ctm.Author.Name},
 		}
 		idx.Data = append(idx.Data, idxEntry)
 	}

--- a/internal/model/toc_test.go
+++ b/internal/model/toc_test.go
@@ -144,6 +144,39 @@ func TestIndex_Filter(t *testing.T) {
 		assert.NotNil(t, idx.findByName("aut/man/mpn2"))
 		assert.NotNil(t, idx.findByName("man/mpn"))
 	})
+	t.Run("filter by sanitized key fields", func(t *testing.T) {
+		idx := &Index{
+			Meta: IndexMeta{},
+			Data: []*IndexEntry{
+				{
+					Name:         "aut-hor/man-ufacturer/m-pn",
+					Manufacturer: SchemaManufacturer{"Man&ufacturer"},
+					Mpn:          "M/PN",
+					Author:       SchemaAuthor{"aut^hor"},
+					Versions: []IndexVersion{
+						{
+							Description: "d2",
+							Version:     Version{"1.0.0"},
+							TMID:        "aut/man/mpn/v1.0.0-20231023121314-abcd12345680.tm.json",
+							Digest:      "abcd12345680",
+							TimeStamp:   "20231023121314",
+						},
+					},
+				},
+			},
+		}
+		author := "aut^hor"
+		manuf := "Man&ufacturer"
+		mpn := "M/PN"
+		idx.Filter(ToSearchParams(&author, &manuf, &mpn, nil, nil, nil))
+		assert.Len(t, idx.Data, 1)
+
+		author = "Aut%hor"
+		manuf = "Man-ufacturer"
+		mpn = "M&pN"
+		idx.Filter(ToSearchParams(&author, &manuf, &mpn, nil, nil, nil))
+		assert.Len(t, idx.Data, 1)
+	})
 }
 
 func prepareIndex() *Index {
@@ -237,6 +270,29 @@ func prepareIndex() *Index {
 						TMID:        "aut/man/mpn2/v1.0.1-20231024121314-abcd12345681.tm.json",
 						Digest:      "abcd12345681",
 						TimeStamp:   "20231024121314",
+					},
+				},
+			},
+		},
+	}
+	return idx
+}
+func prepareTinyIndex() *Index {
+	idx := &Index{
+		Meta: IndexMeta{},
+		Data: []*IndexEntry{
+			{
+				Name:         "aut-hor/man-ufacturer/m-pn",
+				Manufacturer: SchemaManufacturer{"Man&ufacturer"},
+				Mpn:          "M/PN",
+				Author:       SchemaAuthor{"aut^hor"},
+				Versions: []IndexVersion{
+					{
+						Description: "d2",
+						Version:     Version{"1.0.0"},
+						TMID:        "aut/man/mpn/v1.0.0-20231023121314-abcd12345680.tm.json",
+						Digest:      "abcd12345680",
+						TimeStamp:   "20231023121314",
 					},
 				},
 			},

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"text/template"
@@ -526,18 +527,18 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 
 }
 
-func strp(s string) *string { return &s }
-
 func TestFileRepo_Index_Parallel(t *testing.T) {
 	temp, _ := os.MkdirTemp("", "fr")
 	defer os.RemoveAll(temp)
 	templ := template.Must(template.New("tm").Parse(pTempl))
 	mockReader := func(name string) ([]byte, error) {
-		mpns, ver := filepath.Split(name)
-		manufs, mpn := filepath.Split(filepath.Clean(mpns))
-		auths, manuf := filepath.Split(filepath.Clean(manufs))
-		auth := filepath.Base(filepath.Clean(auths))
-		ids := fmt.Sprintf("%s/%s/%s/%s", auth, manuf, mpn, ver)
+		ids, _ := strings.CutPrefix(name, temp+string(filepath.Separator))
+		ids = filepath.ToSlash(ids)
+		parts := strings.Split(ids, "/")
+		assert.Len(t, parts, 4)
+		auths := parts[0]
+		manufs := parts[1]
+		mpns := parts[2]
 		res := bytes.NewBuffer(nil)
 		err := templ.Execute(res, map[string]any{
 			"manufacturer": manufs,

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -124,7 +124,7 @@ func TestValidatesRoot(t *testing.T) {
 		"loc":  "/temp/surely-does-not-exist-5245874598745",
 	}, model.EmptySpec)
 
-	_, err := repo.List(context.Background(), &model.SearchParams{Query: ""})
+	_, err := repo.List(context.Background(), nil)
 	assert.ErrorIs(t, err, ErrRootInvalid)
 	_, err = repo.Versions(context.Background(), "manufacturer/mpn")
 	assert.ErrorIs(t, err, ErrRootInvalid)
@@ -526,6 +526,8 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 
 }
 
+func strp(s string) *string { return &s }
+
 func TestFileRepo_Index_Parallel(t *testing.T) {
 	temp, _ := os.MkdirTemp("", "fr")
 	defer os.RemoveAll(temp)
@@ -536,12 +538,11 @@ func TestFileRepo_Index_Parallel(t *testing.T) {
 		auths, manuf := filepath.Split(filepath.Clean(manufs))
 		auth := filepath.Base(filepath.Clean(auths))
 		ids := fmt.Sprintf("%s/%s/%s/%s", auth, manuf, mpn, ver)
-		id := model.MustParseTMID(ids)
 		res := bytes.NewBuffer(nil)
 		err := templ.Execute(res, map[string]any{
-			"manufacturer": id.Manufacturer,
-			"mpn":          id.Mpn,
-			"author":       id.Author,
+			"manufacturer": manufs,
+			"mpn":          mpns,
+			"author":       auths,
 			"id":           ids,
 		})
 		assert.NoError(t, err)

--- a/internal/repos/http.go
+++ b/internal/repos/http.go
@@ -207,7 +207,8 @@ func (h *HttpRepo) ListCompletions(ctx context.Context, kind string, toComplete 
 	switch kind {
 	case CompletionKindNames:
 		namePrefix, seg := longestPath(toComplete)
-		sr, err := h.List(ctx, &model.SearchParams{Name: namePrefix, Options: model.SearchOptions{NameFilterType: model.PrefixMatch}}) // fixme: search for name = toComplete(less the part after last /)
+		sr, err := h.List(ctx, model.ToSearchParams(nil, nil, nil, &namePrefix, nil,
+			&model.SearchOptions{NameFilterType: model.PrefixMatch}))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
feat: separate display names of key fields from usages in TM name; compare sanitized filter params when searching