### PR TITLE
fix: repo check index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `push`: always reject pushing TMs with same TM name, semantic version and digest by default, but can be enforced by flag `--force`
 - `push`: shows a warning if there is a timestamp collision (retrying after a second has been removed)
 - `list, pull, versions`: return exit code 1 if at least one repo returns an error
-
+- `check index`: do not return error if repo does not contain any TM's and index
 
 ## [v0.0.0-alpha.7]
 

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -90,7 +90,7 @@ func (idx *Index) Sort() {
 			if vc != 0 {
 				return vc
 			}
-			return strings.Compare(b.TMID, a.TMID) // in case of semVer and timestamp uniqueness, use complete ID to ensure stable order
+			return strings.Compare(b.TMID, a.TMID) // in case of semVer and timestamp equality, use complete ID to ensure stable order
 		})
 	}
 	// sort entries ascending

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/wot-oss/tmc/internal/utils"
 )
 
@@ -76,10 +77,20 @@ func (idx *Index) Sort() {
 	if idx.IsEmpty() {
 		return
 	}
-	// sort versions of each entry ascending
+	// sort versions of each entry descending
 	for _, entry := range idx.Data {
 		slices.SortFunc(entry.Versions, func(a IndexVersion, b IndexVersion) int {
-			return strings.Compare(a.TMID, b.TMID)
+			av := semver.MustParse(a.Version.Model)
+			bv := semver.MustParse(b.Version.Model)
+			vc := bv.Compare(av)
+			if vc != 0 {
+				return vc
+			}
+			vc = strings.Compare(b.TimeStamp, a.TimeStamp) // our timestamps can be compared lexicographically
+			if vc != 0 {
+				return vc
+			}
+			return strings.Compare(b.TMID, a.TMID) // in case of semVer and timestamp uniqueness, use complete ID to ensure stable order
 		})
 	}
 	// sort entries ascending

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -68,6 +68,26 @@ type IndexVersion struct {
 	ExternalID  string            `json:"externalID"`
 }
 
+func (idx *Index) IsEmpty() bool {
+	return len(idx.Data) == 0
+}
+
+func (idx *Index) Sort() {
+	if idx.IsEmpty() {
+		return
+	}
+	// sort versions of each entry ascending
+	for _, entry := range idx.Data {
+		slices.SortFunc(entry.Versions, func(a IndexVersion, b IndexVersion) int {
+			return strings.Compare(a.TMID, b.TMID)
+		})
+	}
+	// sort entries ascending
+	slices.SortFunc(idx.Data, func(a *IndexEntry, b *IndexEntry) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
 func (idx *Index) Filter(search *SearchParams) {
 	if search == nil {
 		return

--- a/internal/model/toc_test.go
+++ b/internal/model/toc_test.go
@@ -453,24 +453,40 @@ func TestIndex_Sort(t *testing.T) {
 	assert.NotPanics(t, func() { idx.Sort() })
 
 	// non-empty Data
-	tmName1 := "z/y/x"
-	tmId11 := "z/y/x/v0.1.0-20240606131725-1bbbbbbbbbbb.tm.json"
-	tmId12 := "z/y/x/v0.0.0-20240606131725-1aaaaaaaaaaa.tm.json"
-	tmId13 := "z/y/x/v0.0.1-20240606131725-1ccccccccccc.tm.json"
-	tmName2 := "a/b/c"
-	tmId21 := "a/b/c/v0.0.0-20240606131725-1aaaaaaaaaaa.tm.json"
-	tmId22 := "a/b/c/v0.0.0-20270730131725-1aaaaaaaaaaa.tm.json"
-	tmId23 := "a/b/c/v0.0.0-20240606131725-1bbbbbbbbbbb.tm.json"
+	idxEntry1 := &IndexEntry{
+		Name: "z/y/x",
+		Versions: []IndexVersion{
+			{TMID: "z/y/x/v0.1.0-20240606131725-1bbbbbbbbbbb.tm.json", Version: Version{Model: "0.1.0"}},
+			{TMID: "z/y/x/v0.11.0-20240606131725-1aaaaaaaaaaa.tm.json", Version: Version{Model: "0.11.0"}},
+			{TMID: "z/y/x/v0.2.1-20240606131725-1ccccccccccc.tm.json", Version: Version{Model: "0.2.1"}},
+		},
+	}
+
+	idxEntry2 := &IndexEntry{
+		Name: "a/b/c",
+		Versions: []IndexVersion{
+			{TMID: "a/b/c/v0.0.0-20240606131725-1aaaaaaaaaaa.tm.json", Version: Version{Model: "0.0.0"}},
+			{TMID: "a/b/c/v0.0.0-20270730131725-1aaaaaaaaaaa.tm.json", Version: Version{Model: "0.0.0"}},
+			{TMID: "a/b/c/v0.0.0-20240606131725-1bbbbbbbbbbb.tm.json", Version: Version{Model: "0.0.0"}},
+		},
+	}
 
 	idx.Data = []*IndexEntry{
-		{Name: tmName1, Versions: []IndexVersion{{TMID: tmId11}, {TMID: tmId12}, {TMID: tmId13}}},
-		{Name: tmName2, Versions: []IndexVersion{{TMID: tmId21}, {TMID: tmId22}, {TMID: tmId23}}},
+		idxEntry1, idxEntry2,
+	}
+
+	expIdxData := []*IndexEntry{
+		{
+			Name:     idxEntry2.Name,
+			Versions: []IndexVersion{idxEntry2.Versions[1], idxEntry2.Versions[2], idxEntry2.Versions[0]},
+		},
+		{
+			Name:     idxEntry1.Name,
+			Versions: []IndexVersion{idxEntry1.Versions[1], idxEntry1.Versions[2], idxEntry1.Versions[0]},
+		},
 	}
 
 	idx.Sort()
 
-	assert.Equal(t, tmName2, idx.Data[0].Name)
-	assert.Equal(t, []IndexVersion{{TMID: tmId21}, {TMID: tmId23}, {TMID: tmId22}}, idx.Data[0].Versions)
-	assert.Equal(t, tmName1, idx.Data[1].Name)
-	assert.Equal(t, []IndexVersion{{TMID: tmId12}, {TMID: tmId13}, {TMID: tmId11}}, idx.Data[1].Versions)
+	assert.Equal(t, expIdxData, idx.Data)
 }

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -475,6 +475,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, ids []string, persist bool) 
 			}
 		}
 	}
+	newIndex.Sort()
 	duration := time.Now().Sub(start)
 	// Ignore error as we are sure our struct does not contain channel,
 	// complex or function values that would throw an error.

--- a/internal/repos/fs_res.go
+++ b/internal/repos/fs_res.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -71,7 +70,7 @@ func (f *FileRepo) RangeResources(ctx context.Context, filter model.ResourceFilt
 			log.Error(err.Error(), "resource", res.Name)
 		}
 
-		if errors.Is(err, os.ErrNotExist) {
+		if os.IsNotExist(err) {
 			err = ErrResourceNotExists
 		} else if stat != nil && stat.IsDir() {
 			err = ErrResourceInvalid

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -322,6 +322,7 @@ func TestFileRepo_Delete(t *testing.T) {
 				id1 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json"
 				id2 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
 				id3 := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20240409155220-3f779458e453.tm.json"
+				id4 := "omnicorp-tm-department/omnicorp/omnilamp/v3.11.1-20240409155220-da7dbd7ed830.tm.json"
 				assert.NoError(t, r.Delete(context.Background(), id1))
 				assert.NoError(t, r.Delete(context.Background(), id2))
 				_, err := os.Stat(filepath.Join(r.root, "omnicorp-tm-department/omnicorp/omnilamp/subfolder"))
@@ -329,6 +330,7 @@ func TestFileRepo_Delete(t *testing.T) {
 				_, err = os.Stat(filepath.Join(r.root, "omnicorp-tm-department/omnicorp/omnilamp"))
 				assert.NoError(t, err)
 				assert.NoError(t, r.Delete(context.Background(), id3))
+				assert.NoError(t, r.Delete(context.Background(), id4))
 				_, err = os.Stat(filepath.Join(r.root, "omnicorp-tm-department"))
 				assert.True(t, os.IsNotExist(err))
 				_, err = os.Stat(r.root)
@@ -419,13 +421,14 @@ func TestFileRepo_Index(t *testing.T) {
 		tmName1 := "omnicorp-tm-department/omnicorp/omnilamp"
 		tmId11 := "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20240409155220-80424c65e4e6.tm.json"
 		tmId12 := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20240409155220-3f779458e453.tm.json"
+		tmId13 := "omnicorp-tm-department/omnicorp/omnilamp/v3.11.1-20240409155220-da7dbd7ed830.tm.json"
 
 		tmName2 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder"
 		tmId21 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json"
 		tmId22 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
 
 		// update index with unordered ID's
-		err = r.Index(context.Background(), tmId22, tmId12, tmId21, tmId11)
+		err = r.Index(context.Background(), tmId21, tmId12, tmId22, tmId13, tmId11)
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -433,11 +436,12 @@ func TestFileRepo_Index(t *testing.T) {
 		assert.Equal(t, 2, len(idx.Data))
 
 		assert.Equal(t, tmName1, idx.Data[0].Name)
-		assert.Equal(t, tmId11, idx.Data[0].Versions[0].TMID)
+		assert.Equal(t, tmId13, idx.Data[0].Versions[0].TMID)
 		assert.Equal(t, tmId12, idx.Data[0].Versions[1].TMID)
+		assert.Equal(t, tmId11, idx.Data[0].Versions[2].TMID)
 		assert.Equal(t, tmName2, idx.Data[1].Name)
-		assert.Equal(t, tmId21, idx.Data[1].Versions[0].TMID)
-		assert.Equal(t, tmId22, idx.Data[1].Versions[1].TMID)
+		assert.Equal(t, tmId22, idx.Data[1].Versions[0].TMID)
+		assert.Equal(t, tmId21, idx.Data[1].Versions[1].TMID)
 	})
 }
 
@@ -493,7 +497,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				// then: nothing changes
 				index.Filter(&model.SearchParams{Name: "omnicorp-tm-department/omnicorp/omnilamp"})
 				if assert.Equal(t, 1, len(index.Data)) {
-					assert.Equal(t, 2, len(index.Data[0].Versions))
+					assert.Equal(t, 3, len(index.Data[0].Versions))
 				}
 				names := r.readNamesFile()
 				assert.Equal(t, []string{
@@ -510,7 +514,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				// then: nothing changes
 				index.Filter(&model.SearchParams{Name: "omnicorp-tm-department/omnicorp/omnilamp"})
 				if assert.Equal(t, 1, len(index.Data)) {
-					assert.Equal(t, 2, len(index.Data[0].Versions))
+					assert.Equal(t, 3, len(index.Data[0].Versions))
 				}
 				names := r.readNamesFile()
 				assert.Equal(t, []string{
@@ -529,7 +533,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				// then: version is removed from index
 				index.Filter(&model.SearchParams{Name: "omnicorp-tm-department/omnicorp/omnilamp"})
 				if assert.Equal(t, 1, len(index.Data)) {
-					assert.Equal(t, 1, len(index.Data[0].Versions))
+					assert.Equal(t, 2, len(index.Data[0].Versions))
 				}
 				names := r.readNamesFile()
 				assert.Equal(t, []string{

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -410,6 +410,35 @@ func TestFileRepo_Index(t *testing.T) {
 			"omnicorp-tm-department/omnicorp/omnilamp/subfolder",
 		}, names)
 	})
+
+	t.Run("single id's/index must be sorted", func(t *testing.T) {
+		err := os.Remove(r.indexFilename())
+		assert.NoError(t, err)
+		assert.NoError(t, r.writeNamesFile(nil))
+
+		tmName1 := "omnicorp-tm-department/omnicorp/omnilamp"
+		tmId11 := "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20240409155220-80424c65e4e6.tm.json"
+		tmId12 := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20240409155220-3f779458e453.tm.json"
+
+		tmName2 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder"
+		tmId21 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json"
+		tmId22 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
+
+		// update index with unordered ID's
+		err = r.Index(context.Background(), tmId22, tmId12, tmId21, tmId11)
+		assert.NoError(t, err)
+
+		idx, err := r.readIndex()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(idx.Data))
+
+		assert.Equal(t, tmName1, idx.Data[0].Name)
+		assert.Equal(t, tmId11, idx.Data[0].Versions[0].TMID)
+		assert.Equal(t, tmId12, idx.Data[0].Versions[1].TMID)
+		assert.Equal(t, tmName2, idx.Data[1].Name)
+		assert.Equal(t, tmId21, idx.Data[1].Versions[0].TMID)
+		assert.Equal(t, tmId22, idx.Data[1].Versions[1].TMID)
+	})
 }
 
 func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {

--- a/test/data/index/omnicorp-tm-department/omnicorp/omnilamp/v3.11.1-20240409155220-da7dbd7ed830.tm.json
+++ b/test/data/index/omnicorp-tm-department/omnicorp/omnilamp/v3.11.1-20240409155220-da7dbd7ed830.tm.json
@@ -1,0 +1,40 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@type": "tm:ThingModel",
+  "title": "Lamp Thing Model",
+  "schema:manufacturer": {
+    "schema:name": "omnicorp"
+  },
+  "schema:mpn": "omnilamp",
+  "schema:author": {
+    "schema:name": "omnicorp-tm-department"
+  },
+  "properties": {
+    "status": {
+      "description": "current status of the lamp (on|off)",
+      "type": "string",
+      "readOnly": true
+    }
+  },
+  "actions": {
+    "toggle": {
+      "description": "Turn the lamp on or off"
+    }
+  },
+  "events": {
+    "overheating": {
+      "description": "Lamp reaches a critical temperature (overheating)",
+      "data": {
+        "type": "string"
+      }
+    }
+  },
+  "version": {
+    "model": "v3.11.1"
+  }
+,"id":"omnicorp-tm-department/omnicorp/omnilamp/v3.11.1-20240409155220-da7dbd7ed830.tm.json"}


### PR DESCRIPTION
Changes:

+ `check index` does not return an error anymore, if the file repo has no TM's inside and no index file
+ ìndex is now always sorted after partial updates