### PR TITLE
fix(api): validate empty request body

### DIFF
--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -161,6 +161,10 @@ func (h *TmcHandler) PushThingModel(w http.ResponseWriter, r *http.Request, p se
 		HandleErrorResponse(w, r, err)
 		return
 	}
+	if len(b) == 0 {
+		HandleErrorResponse(w, r, NewBadRequestError(nil, "Empty request body"))
+		return
+	}
 
 	opts := repos.PushOptions{}
 	if p.Force != nil {
@@ -360,6 +364,10 @@ func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, ref m
 
 	if err != nil {
 		HandleErrorResponse(w, r, err)
+		return
+	}
+	if len(b) == 0 {
+		HandleErrorResponse(w, r, NewBadRequestError(nil, "Empty request body"))
 		return
 	}
 

--- a/internal/app/http/handler_test.go
+++ b/internal/app/http/handler_test.go
@@ -638,6 +638,20 @@ func Test_PushThingModel(t *testing.T) {
 		}
 	})
 
+	t.Run("with empty request body", func(t *testing.T) {
+		// given: some empty ThingModel content
+		var emptyContent []byte
+
+		// when: calling the route
+		rec := testutils.NewRequest(http.MethodPost, route).
+			WithHeader(HeaderContentType, MimeJSON).
+			WithBody(emptyContent).
+			RunOnHandler(httpHandler)
+
+		// then: it returns status 400
+		assertResponse400(t, rec, route)
+	})
+
 	t.Run("with validation error", func(t *testing.T) {
 		// given: some invalid ThingModel
 		invalidContent := []byte("some invalid ThingModel")
@@ -800,6 +814,20 @@ func Test_PushAttachment(t *testing.T) {
 		rec := testutils.NewRequest(http.MethodPut, route).
 			WithHeader(HeaderContentType, MimeOctetStream).
 			WithBody(attContent).
+			RunOnHandler(httpHandler)
+
+		// then: it returns status 400
+		assertResponse400(t, rec, route)
+	})
+
+	t.Run("with empty request body", func(t *testing.T) {
+		// given: some empty attachment content
+		var emptyContent []byte
+
+		// when: calling the route
+		rec := testutils.NewRequest(http.MethodPut, route).
+			WithHeader(HeaderContentType, MimeJSON).
+			WithBody(emptyContent).
 			RunOnHandler(httpHandler)
 
 		// then: it returns status 400


### PR DESCRIPTION
Changes:

+ validate empty request body for pushing ThingModel and attachment to align with openapi-spec