### PR TITLE
fix: make import command return an error if there was at least one error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `import`: restore the printout of error to stdout when import was not successful
+
 ### Added
 
 - REST API: added query parameter `force` to POST endpoint `/thing-models` to enforce pushing TMs with same TM name, semantic version and digest

--- a/internal/app/cli/copy.go
+++ b/internal/app/cli/copy.go
@@ -73,7 +73,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 					tmCopied = true
 					switch res.Type {
 					case repos.ImportResultWarning:
-						totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, fmt.Sprintf("copied as %s. TM's version and timestamp clash with existing one %s", res.TmID, res.Err.ExistingId)})
+						totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, fmt.Sprintf("copied as %s. TM's version and timestamp clash with existing one %s", res.TmID, res.IDConflictError().ExistingId)})
 					case repos.ImportResultOK:
 						totalRes = append(totalRes, operationResult{opResultOK, res.TmID, ""})
 					}
@@ -168,7 +168,7 @@ func copyThingModel(ctx context.Context, version model.FoundVersion, target repo
 	if err != nil {
 		Stderrf("Error fetching %s: %v", version.TMID, err)
 		e := fmt.Errorf("cannot fetch %s from repo %s: %w", version.TMID, version.FoundIn, err)
-		return repos.ImportResult{}, e
+		return repos.ImportResultFromError(e)
 	}
 
 	res, err := commands.NewImportCommand(time.Now).ImportFile(ctx, thing, target, opts)

--- a/internal/app/cli/copy.go
+++ b/internal/app/cli/copy.go
@@ -73,7 +73,13 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 					tmCopied = true
 					switch res.Type {
 					case repos.ImportResultWarning:
-						totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, fmt.Sprintf("copied as %s. TM's version and timestamp clash with existing one %s", res.TmID, res.IDConflictError().ExistingId)})
+						warn := res.Message
+						var cErr *repos.ErrTMIDConflict
+						if errors.As(res.Err, &cErr) {
+							warn = fmt.Sprintf("TM's version and timestamp clash with existing one %s", cErr.ExistingId)
+						}
+						msg := fmt.Sprintf("copied as %s with warning: %s", res.TmID, warn)
+						totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, msg})
 					case repos.ImportResultOK:
 						totalRes = append(totalRes, operationResult{opResultOK, res.TmID, ""})
 					}

--- a/internal/app/cli/copy_test.go
+++ b/internal/app/cli/copy_test.go
@@ -219,8 +219,9 @@ func TestCopy(t *testing.T) {
 		var sp *model.SearchParams
 		source.On("List", mock.Anything, sp).Return(copySingleListRes, nil).Once()
 		source.On("Fetch", mock.Anything, tmid).Return(tmid, tmContent1, nil).Once()
+		res, resErr := repos.ImportResultFromError(repos.ErrNotSupported)
 		target.On("Import", mock.Anything, model.MustParseTMID(tmid), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{}).
-			Return(repos.ImportResult{}, repos.ErrNotSupported).Once()
+			Return(res, resErr).Once()
 
 		// when: copying from repo
 		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{})

--- a/internal/app/cli/import_test.go
+++ b/internal/app/cli/import_test.go
@@ -53,16 +53,17 @@ func TestImportExecutor_Import(t *testing.T) {
 		cErr := &repos.ErrTMIDConflict{Type: repos.IdConflictSameContent,
 			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"}
 		r.On("Import", mock.Anything, tmid2, mock.Anything, repos.ImportOptions{}).Return(repos.ImportResult{
-			Type:    repos.ImportResultTMExists,
+			Type:    repos.ImportResultError,
 			TmID:    "",
 			Message: cErr.Error(),
 			Err:     cErr,
 		}, cErr)
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, repos.ImportOptions{})
-		assert.NoError(t, err)
-		assert.Len(t, res, 1)
-		assert.Equal(t, repos.ImportResultTMExists, res[0].Type)
-		assert.Equal(t, cErr, res[0].Err)
+		assert.Error(t, err)
+		if assert.Len(t, res, 1) {
+			assert.Equal(t, repos.ImportResultError, res[0].Type)
+			assert.Equal(t, cErr, res[0].Err)
+		}
 	})
 
 	t.Run("import fails", func(t *testing.T) {
@@ -77,8 +78,9 @@ func TestImportExecutor_Import(t *testing.T) {
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, repos.ImportOptions{})
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, resErr)
-		assert.Len(t, res, 1)
-		assert.ErrorIs(t, res[0].Err, resErr)
+		if assert.Len(t, res, 1) {
+			assert.ErrorIs(t, res[0].Err, resErr)
+		}
 	})
 
 	t.Run("import with optPath", func(t *testing.T) {
@@ -92,8 +94,9 @@ func TestImportExecutor_Import(t *testing.T) {
 
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, opts)
 		assert.NoError(t, err)
-		assert.Len(t, res, 1)
-		assert.Equal(t, repos.ImportResultOK, res[0].Type)
+		if assert.Len(t, res, 1) {
+			assert.Equal(t, repos.ImportResultOK, res[0].Type)
+		}
 	})
 }
 
@@ -114,7 +117,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"}
 		r.On("Import", mock.Anything, tmid, mock.Anything, opts).Return(
 			repos.ImportResult{
-				Type:    repos.ImportResultTMExists,
+				Type:    repos.ImportResultError,
 				TmID:    "",
 				Message: cErr.Error(),
 				Err:     cErr,
@@ -124,7 +127,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 			ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json"}
 		r.On("Import", mock.Anything, tmid, mock.Anything, opts).Return(
 			repos.ImportResult{
-				Type:    repos.ImportResultTMExists,
+				Type:    repos.ImportResultError,
 				TmID:    "",
 				Message: cErr.Error(),
 				Err:     cErr,
@@ -134,13 +137,13 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return(nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), false, opts)
-		assert.NoError(t, err)
-		assert.Len(t, res, 4)
-		assert.Equalf(t, repos.ImportResultOK, res[0].Type, "res[0]: want ImportResultOK, got %v", res[0].Type)
-		assert.Equalf(t, repos.ImportResultOK, res[1].Type, "res[1]: want ImportResultOK, got %v", res[1].Type)
-		assert.Equalf(t, repos.ImportResultTMExists, res[2].Type, "res[2]: want ImportResultTMExists, got %v", res[2].Type)
-		assert.Equalf(t, repos.ImportResultTMExists, res[3].Type, "res[3]: want ImportResultTMExists, got %v", res[3].Type)
-
+		assert.Error(t, err)
+		if assert.Len(t, res, 4) {
+			assert.Equalf(t, repos.ImportResultOK, res[0].Type, "res[0]: want ImportResultOK, got %v", res[0].Type)
+			assert.Equalf(t, repos.ImportResultOK, res[1].Type, "res[1]: want ImportResultOK, got %v", res[1].Type)
+			assert.Equalf(t, repos.ImportResultError, res[2].Type, "res[2]: want ImportResultError, got %v", res[2].Type)
+			assert.Equalf(t, repos.ImportResultError, res[3].Type, "res[3]: want ImportResultError, got %v", res[3].Type)
+		}
 	})
 
 	t.Run("import directory with optPath", func(t *testing.T) {
@@ -163,11 +166,11 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), false, opts)
 		assert.NoError(t, err)
-		assert.Len(t, res, 4)
-		for i, r := range res {
-			assert.Equalf(t, repos.ImportResultOK, r.Type, "res[%d]: want ImportResultOK, got %v", i, r.Type)
+		if assert.Len(t, res, 4) {
+			for i, r := range res {
+				assert.Equalf(t, repos.ImportResultOK, r.Type, "res[%d]: want ImportResultOK, got %v", i, r.Type)
+			}
 		}
-
 	})
 
 	t.Run("import directory with optTree", func(t *testing.T) {

--- a/internal/app/cli/import_test.go
+++ b/internal/app/cli/import_test.go
@@ -72,11 +72,13 @@ func TestImportExecutor_Import(t *testing.T) {
 			return time.Date(2023, time.August, 11, 12, 32, 43, 0, time.UTC)
 		}
 		e := NewImportExecutor(now)
-		r.On("Import", mock.Anything, tmid3, mock.Anything, repos.ImportOptions{}).Return(repos.ImportResult{}, errors.New("unexpected"))
+		ret, resErr := repos.ImportResultFromError(errors.New("unexpected"))
+		r.On("Import", mock.Anything, tmid3, mock.Anything, repos.ImportOptions{}).Return(ret, resErr)
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, repos.ImportOptions{})
 		assert.Error(t, err)
+		assert.ErrorIs(t, err, resErr)
 		assert.Len(t, res, 1)
-		assert.Equal(t, repos.ImportResult{}, res[0])
+		assert.ErrorIs(t, res[0].Err, resErr)
 	})
 
 	t.Run("import with optPath", func(t *testing.T) {

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -290,7 +290,7 @@ func toImportThingModelResponse(res repos.ImportResult) server.ImportThingModelR
 	}
 	data.Message = &res.Message
 	if res.Type == repos.ImportResultWarning {
-		code := res.Err.Code()
+		code := res.IDConflictError().Code()
 		data.Code = &code
 	}
 	return server.ImportThingModelResponse{

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -289,8 +289,9 @@ func toImportThingModelResponse(res repos.ImportResult) server.ImportThingModelR
 		TmID: res.TmID,
 	}
 	data.Message = &res.Message
-	if res.Type == repos.ImportResultWarning {
-		code := res.IDConflictError().Code()
+	var ce repos.CodedError
+	if errors.As(res.Err, &ce) {
+		code := ce.Code()
 		data.Code = &code
 	}
 	return server.ImportThingModelResponse{

--- a/internal/app/http/handler_test.go
+++ b/internal/app/http/handler_test.go
@@ -656,7 +656,7 @@ func Test_ImportThingModel(t *testing.T) {
 		// given: some invalid ThingModel
 		invalidContent := []byte("some invalid ThingModel")
 		var err2 error = &jsonschema.ValidationError{}
-		pr, err := repos.ImportResult{}, err2
+		pr, err := repos.ImportResultFromError(err2)
 		hs.On("ImportThingModel", mock.Anything, invalidContent, repos.ImportOptions{}).Return(pr, err).Once()
 		// when: calling the route
 
@@ -671,7 +671,7 @@ func Test_ImportThingModel(t *testing.T) {
 
 	t.Run("with too long name", func(t *testing.T) {
 		// given: a thing model with too long name
-		pr, err := repos.ImportResult{}, fmt.Errorf("%w: %s", commands.ErrTMNameTooLong, "this-name-is-too-long")
+		pr, err := repos.ImportResultFromError(fmt.Errorf("%w: %s", commands.ErrTMNameTooLong, "this-name-is-too-long"))
 		hs.On("ImportThingModel", mock.Anything, tmContent, repos.ImportOptions{}).Return(pr, err).Once()
 		// when: calling the route
 
@@ -770,7 +770,7 @@ func Test_ImportThingModel(t *testing.T) {
 	t.Run("with unknown error", func(t *testing.T) {
 		// and given: some invalid ThingModel
 		invalidContent := []byte("some invalid ThingModel")
-		result, _ := repos.ImportResult{}, unknownErr
+		result, _ := repos.ImportResultFromError(unknownErr)
 		hs.On("ImportThingModel", mock.Anything, invalidContent, repos.ImportOptions{}).Return(result, unknownErr).Once()
 		// when: calling the route
 

--- a/internal/app/http/handler_test.go
+++ b/internal/app/http/handler_test.go
@@ -720,7 +720,7 @@ func Test_ImportThingModel(t *testing.T) {
 			ExistingId: "existing-id",
 		}
 		result := repos.ImportResult{
-			Type:    repos.ImportResultTMExists,
+			Type:    repos.ImportResultError,
 			TmID:    "",
 			Message: cErr.Error(),
 			Err:     cErr,

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -163,7 +163,7 @@ func (dhs *defaultHandlerService) ImportThingModel(ctx context.Context, file []b
 
 	repo, err := repos.Get(importRepo)
 	if err != nil {
-		return repos.ImportResult{}, err
+		return repos.ImportResultFromError(err)
 	}
 	res, err := commands.NewImportCommand(time.Now).ImportFile(ctx, file, repo, opts)
 	if err != nil {
@@ -172,7 +172,7 @@ func (dhs *defaultHandlerService) ImportThingModel(ctx context.Context, file []b
 	if res.IsSuccessful() {
 		err = repo.Index(ctx, res.TmID)
 		if err != nil {
-			return repos.ImportResult{}, err
+			return repos.ImportResultFromError(err)
 		}
 	}
 

--- a/internal/app/http/service_test.go
+++ b/internal/app/http/service_test.go
@@ -536,8 +536,9 @@ func TestService_ImportThingModel(t *testing.T) {
 		rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, importTarget, r, nil))
 		// when: importing ThingModel
 		res, err := underTest.ImportThingModel(nil, invalidContent, repos.ImportOptions{})
-		// then: it returns an empty ImportResult
-		assert.Equal(t, repos.ImportResult{}, res)
+		// then: it returns an error ImportResult
+		assert.Equal(t, repos.ImportResultError, res.Type)
+		assert.Equal(t, err, res.Err)
 		// and then: there is an error
 		assert.ErrorContains(t, err, "invalid character 'i' looking for beginning of value")
 	})
@@ -547,8 +548,9 @@ func TestService_ImportThingModel(t *testing.T) {
 		rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, importTarget, nil, repos.ErrRepoNotFound))
 		// when: importing ThingModel
 		res, err := underTest.ImportThingModel(nil, []byte("some TM content"), repos.ImportOptions{})
-		// then: it returns empty import result
-		assert.Equal(t, repos.ImportResult{}, res)
+		// then: it returns an error import result
+		assert.Equal(t, repos.ImportResultError, res.Type)
+		assert.Equal(t, err, res.Err)
 		// and then: there is an error
 		assert.ErrorContains(t, err, "repo not found")
 		// and then: the error says that the repo cannot be found

--- a/internal/app/http/service_test.go
+++ b/internal/app/http/service_test.go
@@ -565,7 +565,7 @@ func TestService_ImportThingModel(t *testing.T) {
 			ExistingId: "existing-id",
 		}
 		expRes := repos.ImportResult{
-			Type:    repos.ImportResultTMExists,
+			Type:    repos.ImportResultError,
 			TmID:    "",
 			Message: cErr.Error(),
 			Err:     cErr,

--- a/internal/commands/import.go
+++ b/internal/commands/import.go
@@ -42,11 +42,11 @@ func (c *ImportCommand) ImportFile(ctx context.Context, raw []byte, repo repos.R
 	tm, err := validate.ValidateThingModel(raw)
 	if err != nil {
 		log.Error("validation failed", "error", err)
-		return repos.ImportResult{}, err
+		return repos.ImportResultFromError(err)
 	}
 	prepared, id, err := prepareToImport(c.now, tm, raw, opts.OptPath)
 	if err != nil {
-		return repos.ImportResult{}, err
+		return repos.ImportResultFromError(err)
 	}
 
 	res, err := repo.Import(ctx, id, prepared, opts)

--- a/internal/commands/import_test.go
+++ b/internal/commands/import_test.go
@@ -223,8 +223,11 @@ func TestImportToRepoUnversioned(t *testing.T) {
 		assert.False(t, res.IsSuccessful())
 		if assert.NotNil(t, res.Err) {
 			assert.Equal(t, err, res.Err)
-			assert.Equal(t, repos.ImportResultTMExists, res.Type)
-			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.IDConflictError().Type)
+			assert.Equal(t, repos.ImportResultError, res.Type)
+			var cErr *repos.ErrTMIDConflict
+			if assert.ErrorAs(t, res.Err, &cErr) {
+				assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), cErr.Type)
+			}
 		}
 		entries, _ := os.ReadDir(testTMDir)
 		assert.Len(t, entries, 1)
@@ -247,13 +250,17 @@ func TestImportToRepoUnversioned(t *testing.T) {
 		res, err := c.ImportFile(context.Background(), raw, repo, repos.ImportOptions{})
 		assert.Error(t, err)
 		if assert.NotNil(t, res.Err) {
-			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.IDConflictError().Type)
+			var cErr *repos.ErrTMIDConflict
+			if assert.ErrorAs(t, res.Err, &cErr) {
+				assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), cErr.Type)
+			}
 			assert.Equal(t, err, res.Err)
 		}
 		assert.False(t, res.IsSuccessful())
 		entries, _ := os.ReadDir(testTMDir)
-		assert.Len(t, entries, 2)
-		assert.Equal(t, firstSaved, entries[0].Name())
+		if assert.Len(t, entries, 2) {
+			assert.Equal(t, firstSaved, entries[0].Name())
+		}
 	})
 	t.Run("force writing the changed back file", func(t *testing.T) {
 		// force writing the changed back file with option Force - saves as new version

--- a/internal/commands/import_test.go
+++ b/internal/commands/import_test.go
@@ -224,7 +224,7 @@ func TestImportToRepoUnversioned(t *testing.T) {
 		if assert.NotNil(t, res.Err) {
 			assert.Equal(t, err, res.Err)
 			assert.Equal(t, repos.ImportResultTMExists, res.Type)
-			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.Err.Type)
+			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.IDConflictError().Type)
 		}
 		entries, _ := os.ReadDir(testTMDir)
 		assert.Len(t, entries, 1)
@@ -247,7 +247,7 @@ func TestImportToRepoUnversioned(t *testing.T) {
 		res, err := c.ImportFile(context.Background(), raw, repo, repos.ImportOptions{})
 		assert.Error(t, err)
 		if assert.NotNil(t, res.Err) {
-			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.Err.Type)
+			assert.Equal(t, repos.IdConflictType(repos.IdConflictSameContent), res.IDConflictError().Type)
 			assert.Equal(t, err, res.Err)
 		}
 		assert.False(t, res.IsSuccessful())

--- a/internal/repos/errors.go
+++ b/internal/repos/errors.go
@@ -32,6 +32,10 @@ func init() {
 	ErrAttachmentNotFound = NewErrNotFound("attachment")
 }
 
+type CodedError interface {
+	Code() string
+}
+
 type ErrTMIDConflict struct {
 	Type       IdConflictType
 	ExistingId string

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -57,14 +57,14 @@ func NewFileRepo(config map[string]any, spec model.RepoSpec) (*FileRepo, error) 
 func (f *FileRepo) Import(ctx context.Context, id model.TMID, raw []byte, opts ImportOptions) (ImportResult, error) {
 	if len(raw) == 0 {
 		err := errors.New("nothing to write")
-		return ImportResult{}, err
+		return ImportResultFromError(err)
 	}
 	idS := id.String()
 	fullPath, dir, _ := f.filenames(idS)
 	err := os.MkdirAll(dir, defaultDirPermissions)
 	if err != nil {
 		err := fmt.Errorf("could not create directory %s: %w", dir, err)
-		return ImportResult{}, err
+		return ImportResultFromError(err)
 	}
 
 	match, existingId := f.getExistingID(idS)
@@ -79,7 +79,7 @@ func (f *FileRepo) Import(ctx context.Context, id model.TMID, raw []byte, opts I
 	err = utils.AtomicWriteFile(fullPath, raw, defaultFilePermissions)
 	if err != nil {
 		err := fmt.Errorf("could not write TM to catalog: %v", err)
-		return ImportResult{}, err
+		return ImportResultFromError(err)
 	}
 	log.Info("saved Thing Model file", "filename", fullPath)
 

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -73,7 +73,7 @@ func (f *FileRepo) Import(ctx context.Context, id model.TMID, raw []byte, opts I
 	if (match == idMatchDigest || match == idMatchFull) && !opts.Force {
 		log.Info(fmt.Sprintf("Same TM content already exists under ID %v", existingId))
 		err := &ErrTMIDConflict{Type: IdConflictSameContent, ExistingId: existingId}
-		return ImportResult{Type: ImportResultTMExists, Message: err.Error(), Err: err}, err
+		return ImportResult{Type: ImportResultError, Message: err.Error(), Err: err}, err
 	}
 
 	err = utils.AtomicWriteFile(fullPath, raw, defaultFilePermissions)

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -205,7 +205,7 @@ func TestFileRepo_Push(t *testing.T) {
 	res, err := r.Import(context.Background(), model.MustParseTMID(id2), []byte("{}"), ImportOptions{})
 	expCErr := &ErrTMIDConflict{Type: IdConflictSameContent, ExistingId: "omnicorp-tm-department/omnicorp/omnilamp/v1.0.0-20231208142856-a49617d2e4fc.tm.json"}
 	assert.Equal(t, expCErr, err)
-	assert.Equal(t, ImportResult{Type: ImportResultTMExists, Message: expCErr.Error(), Err: expCErr}, res)
+	assert.Equal(t, ImportResult{Type: ImportResultError, Message: expCErr.Error(), Err: expCErr}, res)
 
 	id3 := "omnicorp-tm-department/omnicorp/omnilamp/v1.0.0-20231219123456-f49617d2e4fc.tm.json"
 	_, err = r.Import(context.Background(), model.MustParseTMID(id3), []byte("{}"), ImportOptions{})

--- a/internal/repos/http.go
+++ b/internal/repos/http.go
@@ -79,7 +79,7 @@ func newBaseHttpRepo(config map[string]any, spec model.RepoSpec) (baseHttpRepo, 
 }
 
 func (h *HttpRepo) Import(ctx context.Context, id model.TMID, raw []byte, opts ImportOptions) (ImportResult, error) {
-	return ImportResult{}, ErrNotSupported
+	return ImportResultFromError(ErrNotSupported)
 }
 func (h *HttpRepo) Delete(ctx context.Context, id string) error {
 	return ErrNotSupported

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -42,10 +42,9 @@ var SupportedTypes = []string{RepoTypeFile, RepoTypeHttp, RepoTypeTmc}
 type ImportResultType int
 
 const (
-	ImportResultOK       = ImportResultType(iota + 1)
-	ImportResultWarning  // imported but with warning
-	ImportResultTMExists // not imported because of conflict
-	ImportResultError    // not imported because of other error
+	ImportResultOK      = ImportResultType(iota + 1)
+	ImportResultWarning // imported but with warning
+	ImportResultError   // not imported because of error
 )
 
 func (t ImportResultType) String() string {
@@ -54,8 +53,6 @@ func (t ImportResultType) String() string {
 		return "OK"
 	case ImportResultWarning:
 		return "warning"
-	case ImportResultTMExists:
-		return "exists"
 	case ImportResultError:
 		return "error"
 	default:
@@ -78,19 +75,6 @@ func ImportResultFromError(err error) (ImportResult, error) {
 		Message: err.Error(),
 		Err:     err,
 	}, err
-}
-
-func (r ImportResult) IDConflictError() *ErrTMIDConflict {
-	switch r.Type {
-	case ImportResultTMExists, ImportResultWarning:
-		var cErr *ErrTMIDConflict
-		if errors.As(r.Err, &cErr) {
-			return cErr
-		}
-		return nil
-	default:
-		return nil
-	}
 }
 
 func (r ImportResult) String() string {

--- a/internal/repos/tmc.go
+++ b/internal/repos/tmc.go
@@ -267,11 +267,7 @@ func (t TmcRepo) Import(ctx context.Context, id model.TMID, raw []byte, opts Imp
 			if err != nil {
 				return ImportResultFromError(err)
 			}
-			return ImportResult{
-				Type:    ImportResultTMExists,
-				Message: cErr.Error(),
-				Err:     cErr,
-			}, cErr
+			return ImportResultFromError(cErr)
 		case http.StatusInternalServerError, http.StatusUnauthorized, http.StatusBadRequest:
 			err := errors.New(detail)
 			return ImportResultFromError(err)


### PR DESCRIPTION
- chore: remove ImportTypeTMExists in favor of ImportTypeError
- fix: make import command return an error if there was at least one error