### PR TITLE
feat: return error on attachment import when it already exists and add a flag to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `repo`: added flag for setting a repository description when adding/changing repo config
 - REST API: added source repository name to inventory responses
 - added setting/storing/detecting of attachment media types
+- return error on attachment import when it already exists and add a flag to override
 
 ### Changed
 

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -421,6 +421,7 @@ paths:
         - $ref: '#/components/parameters/TMID'
         - $ref: '#/components/parameters/AttachmentFileName'
         - $ref: '#/components/parameters/RepoDisambiguator'
+        - $ref: '#/components/parameters/ForceImport'
       requestBody:
         description: Add a new attachment or overwrite an existing one
         content:
@@ -440,6 +441,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          description: Conflict, attachment already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal error
           content:
@@ -529,6 +536,7 @@ paths:
         - $ref: '#/components/parameters/TMName'
         - $ref: '#/components/parameters/AttachmentFileName'
         - $ref: '#/components/parameters/RepoDisambiguator'
+        - $ref: '#/components/parameters/ForceImport'
       requestBody:
         description: Add a new attachment or overwrite an existing one
         content:
@@ -548,6 +556,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          description: Conflict, attachment already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal error
           content:
@@ -596,12 +610,7 @@ paths:
       operationId: importThingModel
       parameters:
         - $ref: '#/components/parameters/RepoDisambiguator'
-        - name: force
-          in: query
-          description: flag to force the import, ignoring any conflicts with existing TMs
-          required: false
-          schema:
-            type: string
+        - $ref: '#/components/parameters/ForceImport'
         - name: optPath
           in: query
           description: optional path parts to append to the target path (and id) of imported TM, after the mandatory path structure
@@ -1321,6 +1330,13 @@ components:
           value: 'siemens/siemens/poc1000'
         withOptionalPath:
           value: 'siemens/siemens/poc1000/variants/with-bluetooth'
+    ForceImport:
+      name: force
+      in: query
+      description: flag to force the import, ignoring any conflicts with existing data
+      required: false
+      schema:
+        type: boolean
     AttachmentFileName:
       name: attachmentFileName
       in: path

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -416,7 +416,7 @@ paths:
         - attachments
       summary: Upload an attachment to a Thing Model
       description: Upload an attachment to a Thing Model
-      operationId: putThingModelAttachmentByName
+      operationId: putTMIDAttachment
       parameters:
         - $ref: '#/components/parameters/TMID'
         - $ref: '#/components/parameters/AttachmentFileName'

--- a/cmd/attachment/attachment_import.go
+++ b/cmd/attachment/attachment_import.go
@@ -33,8 +33,8 @@ var attachmentImportCmd = &cobra.Command{
 func attachmentImport(command *cobra.Command, args []string) {
 	spec := cmd.RepoSpec(command)
 	mediaType := command.Flag("media-type").Value.String()
-
-	err := cli.AttachmentImport(context.Background(), spec, args[0], args[1], mediaType)
+	force, _ := command.Flags().GetBool("force")
+	err := cli.AttachmentImport(context.Background(), spec, args[0], args[1], mediaType, force)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -43,4 +43,5 @@ func attachmentImport(command *cobra.Command, args []string) {
 func init() {
 	attachmentCmd.AddCommand(attachmentImportCmd)
 	attachmentImportCmd.Flags().StringP("media-type", "m", "", "Media type of the attachment")
+	attachmentImportCmd.Flags().Bool("force", false, `Force import, even if there is conflict with existing attachment.`)
 }

--- a/internal/app/cli/attachment.go
+++ b/internal/app/cli/attachment.go
@@ -70,7 +70,7 @@ func printAttachments(atts []model.FoundAttachment) {
 
 }
 
-func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, filename string, mediaType string) error {
+func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, filename string, mediaType string, force bool) error {
 	abs, err := filepath.Abs(filename)
 	if err != nil {
 		Stderrf("Error expanding file name %s: %v", filename, err)
@@ -89,7 +89,7 @@ func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, file
 	err = commands.ImportAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId), model.Attachment{
 		Name:      filepath.Base(filename),
 		MediaType: mediaType,
-	}, raw)
+	}, raw, force)
 	if err != nil {
 		Stderrf("Failed to put attachment %s to %s: %v", filename, tmNameOrId, err)
 	}

--- a/internal/app/cli/attachment.go
+++ b/internal/app/cli/attachment.go
@@ -59,7 +59,7 @@ func printAttachments(atts []model.FoundAttachment) {
 	colWidth := columnWidth()
 	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	_, _ = fmt.Fprintf(table, "NAME\tMediaType\tREPO\n")
+	_, _ = fmt.Fprintf(table, "NAME\tMEDIATYPE\tREPO\n")
 	for _, value := range atts {
 		name := value.Name
 		ct := elideString(fmt.Sprintf("%v", value.MediaType), colWidth)

--- a/internal/app/cli/attachment.go
+++ b/internal/app/cli/attachment.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -60,7 +59,7 @@ func printAttachments(atts []model.FoundAttachment) {
 	colWidth := columnWidth()
 	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	_, _ = fmt.Fprintf(table, "NAME\tMIME\tREPO\n")
+	_, _ = fmt.Fprintf(table, "NAME\tMediaType\tREPO\n")
 	for _, value := range atts {
 		name := value.Name
 		ct := elideString(fmt.Sprintf("%v", value.MediaType), colWidth)
@@ -89,7 +88,7 @@ func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, file
 	}
 	err = commands.ImportAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId), model.Attachment{
 		Name:      filepath.Base(filename),
-		MediaType: utils.DetectMediaType(mediaType, filename, bytes.NewBuffer(raw)),
+		MediaType: mediaType,
 	}, raw)
 	if err != nil {
 		Stderrf("Failed to put attachment %s to %s: %v", filename, tmNameOrId, err)

--- a/internal/app/cli/attachment_test.go
+++ b/internal/app/cli/attachment_test.go
@@ -65,8 +65,8 @@ func TestAttachmentImport(t *testing.T) {
 	attFile := "../../../test/data/attachments/" + attName
 	attContent, err := os.ReadFile(attFile)
 	assert.NoError(t, err)
-	r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: ""}, attContent).Return(nil).Once()
-	err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attFile, "")
+	r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: ""}, attContent, true).Return(nil).Once()
+	err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attFile, "", true)
 	assert.NoError(t, err)
 }
 

--- a/internal/app/cli/attachment_test.go
+++ b/internal/app/cli/attachment_test.go
@@ -34,7 +34,7 @@ func TestAttachmentList(t *testing.T) {
 		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName)
 		assert.NoError(t, err)
 		stdout := getOutput()
-		assert.Equal(t, "NAME            MediaType        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
+		assert.Equal(t, "NAME            MEDIATYPE        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
 	})
 	t.Run("with resourceId", func(t *testing.T) {
 		restore, getOutput := testutils.ReplaceStdout()
@@ -52,7 +52,7 @@ func TestAttachmentList(t *testing.T) {
 		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmId)
 		assert.NoError(t, err)
 		stdout := getOutput()
-		assert.Equal(t, "NAME            MediaType        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
+		assert.Equal(t, "NAME            MEDIATYPE        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
 	})
 }
 

--- a/internal/app/cli/attachment_test.go
+++ b/internal/app/cli/attachment_test.go
@@ -34,7 +34,7 @@ func TestAttachmentList(t *testing.T) {
 		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName)
 		assert.NoError(t, err)
 		stdout := getOutput()
-		assert.Equal(t, "NAME            MIME             REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
+		assert.Equal(t, "NAME            MediaType        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
 	})
 	t.Run("with resourceId", func(t *testing.T) {
 		restore, getOutput := testutils.ReplaceStdout()
@@ -52,7 +52,7 @@ func TestAttachmentList(t *testing.T) {
 		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmId)
 		assert.NoError(t, err)
 		stdout := getOutput()
-		assert.Equal(t, "NAME            MIME             REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
+		assert.Equal(t, "NAME            MediaType        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
 	})
 }
 
@@ -65,7 +65,7 @@ func TestAttachmentImport(t *testing.T) {
 	attFile := "../../../test/data/attachments/" + attName
 	attContent, err := os.ReadFile(attFile)
 	assert.NoError(t, err)
-	r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: "text/plain; charset=utf-8"}, attContent).Return(nil).Once()
+	r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: ""}, attContent).Return(nil).Once()
 	err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attFile, "")
 	assert.NoError(t, err)
 }

--- a/internal/app/cli/copy.go
+++ b/internal/app/cli/copy.go
@@ -44,7 +44,6 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 	var totalRes []operationResult
 	var copiedIDs []string
 	for _, entry := range searchResult.Entries {
-		tmCopied := false
 		for _, version := range entry.Versions {
 			select {
 			case <-ctx.Done():
@@ -52,55 +51,59 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 			default:
 			}
 			res, cErr := copyThingModel(ctx, version, target, opts)
-			if cErr != nil {
-				var errExists *repos.ErrTMIDConflict
-				if errors.As(cErr, &errExists) {
-					totalRes = append(totalRes, operationResult{opResultErr, version.TMID, fmt.Sprintf("already exists as %s", errExists.ExistingId)})
-				} else {
-					cErr = fmt.Errorf("error copying TM %s: %w", version.TMID, cErr)
-					totalRes = append(totalRes, operationResult{opResultErr, version.TMID, fmt.Sprintf("%v", cErr)})
-				}
+			tmExisted := false
+			var errExists *repos.ErrTMIDConflict
+			if errors.As(cErr, &errExists) { // TM exists in target -> add error result and store the total error, but don't skip copying attachments
+				tmExisted = true
+				totalRes = append(totalRes, operationResult{opResultErr, version.TMID, fmt.Sprintf("already exists as %s", errExists.ExistingId)})
 				if err == nil {
 					err = cErr
 				}
 			} else {
+				if cErr != nil {
+					cErr = fmt.Errorf("error copying TM %s: %w", version.TMID, cErr)
+					totalRes = append(totalRes, operationResult{opResultErr, version.TMID, fmt.Sprintf("%v", cErr)})
+					if err == nil {
+						err = cErr
+					}
+					continue
+				}
+			}
+
+			if !tmExisted {
 				copiedIDs = append(copiedIDs, res.TmID)
 				iErr := target.Index(ctx, res.TmID) // need to index the TM to be able to push attachments to it
 				if iErr != nil {
 					totalRes = append(totalRes, operationResult{opResultErr, res.TmID, "could not update index"})
 					continue
-				} else {
-					tmCopied = true
-					switch res.Type {
-					case repos.ImportResultWarning:
-						warn := res.Message
-						var cErr *repos.ErrTMIDConflict
-						if errors.As(res.Err, &cErr) {
-							warn = fmt.Sprintf("TM's version and timestamp clash with existing one %s", cErr.ExistingId)
-						}
-						msg := fmt.Sprintf("copied as %s with warning: %s", res.TmID, warn)
-						totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, msg})
-					case repos.ImportResultOK:
-						totalRes = append(totalRes, operationResult{opResultOK, res.TmID, ""})
-					}
-					spec := model.NewSpecFromFoundSource(entry.FoundIn)
-					aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMIDAttachmentContainerRef(version.TMID), version.Attachments, opts.Force)
-					if err == nil && aErr != nil {
-						err = aErr
-					}
-					totalRes = append(totalRes, aRes...)
 				}
 			}
-		}
-		if tmCopied { // copy tm name attachments if at least one tm has been copied successfully
-			spec := model.NewSpecFromFoundSource(entry.Versions[0].FoundIn)
-			aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMNameAttachmentContainerRef(entry.Name), entry.Attachments, opts.Force)
+
+			switch res.Type {
+			case repos.ImportResultWarning:
+				warn := res.Message
+				var cErr *repos.ErrTMIDConflict
+				if errors.As(res.Err, &cErr) {
+					warn = fmt.Sprintf("TM's version and timestamp clash with existing one %s", cErr.ExistingId)
+				}
+				msg := fmt.Sprintf("copied as %s with warning: %s", res.TmID, warn)
+				totalRes = append(totalRes, operationResult{opResultWarn, version.TMID, msg})
+			case repos.ImportResultOK:
+				totalRes = append(totalRes, operationResult{opResultOK, res.TmID, ""})
+			}
+			spec := model.NewSpecFromFoundSource(entry.FoundIn)
+			aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMIDAttachmentContainerRef(version.TMID), version.Attachments, opts.Force)
 			if err == nil && aErr != nil {
 				err = aErr
 			}
 			totalRes = append(totalRes, aRes...)
 		}
-
+		spec := model.NewSpecFromFoundSource(entry.Versions[0].FoundIn)
+		aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMNameAttachmentContainerRef(entry.Name), entry.Attachments, opts.Force)
+		if err == nil && aErr != nil {
+			err = aErr
+		}
+		totalRes = append(totalRes, aRes...)
 	}
 
 	if err == nil && len(errs) > 0 {

--- a/internal/app/cli/copy.go
+++ b/internal/app/cli/copy.go
@@ -84,7 +84,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 						totalRes = append(totalRes, operationResult{opResultOK, res.TmID, ""})
 					}
 					spec := model.NewSpecFromFoundSource(entry.FoundIn)
-					aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMIDAttachmentContainerRef(version.TMID), version.Attachments)
+					aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMIDAttachmentContainerRef(version.TMID), version.Attachments, opts.Force)
 					if err == nil && aErr != nil {
 						err = aErr
 					}
@@ -94,7 +94,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 		}
 		if tmCopied { // copy tm name attachments if at least one tm has been copied successfully
 			spec := model.NewSpecFromFoundSource(entry.Versions[0].FoundIn)
-			aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMNameAttachmentContainerRef(entry.Name), entry.Attachments)
+			aRes, aErr := copyAttachments(ctx, spec, target, model.NewTMNameAttachmentContainerRef(entry.Name), entry.Attachments, opts.Force)
 			if err == nil && aErr != nil {
 				err = aErr
 			}
@@ -123,7 +123,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 	return err
 }
 
-func copyAttachments(ctx context.Context, spec model.RepoSpec, toRepo repos.Repo, ref model.AttachmentContainerRef, attachments []model.Attachment) ([]operationResult, error) {
+func copyAttachments(ctx context.Context, spec model.RepoSpec, toRepo repos.Repo, ref model.AttachmentContainerRef, attachments []model.Attachment, force bool) ([]operationResult, error) {
 	relDir, err := model.RelAttachmentsDir(ref)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func copyAttachments(ctx context.Context, spec model.RepoSpec, toRepo repos.Repo
 			})
 			continue
 		}
-		wErr := toRepo.ImportAttachment(ctx, ref, att, bytes)
+		wErr := toRepo.ImportAttachment(ctx, ref, att, bytes, force)
 		if wErr != nil {
 			if err == nil {
 				err = wErr

--- a/internal/app/cli/copy_test.go
+++ b/internal/app/cli/copy_test.go
@@ -129,21 +129,21 @@ func TestCopy(t *testing.T) {
 		source.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), "CHANGELOG.md").Return(changelogContent, nil).Once()
-		target.On("Import", mock.Anything, model.MustParseTMID(tmID_1), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{}).
+		target.On("Import", mock.Anything, model.MustParseTMID(tmID_1), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{Force: true}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmID_1, Message: "", Err: nil}, nil).Once()
-		target.On("Import", mock.Anything, model.MustParseTMID(tmID_2), utils.NormalizeLineEndings(tmContent2), repos.ImportOptions{}).
+		target.On("Import", mock.Anything, model.MustParseTMID(tmID_2), utils.NormalizeLineEndings(tmContent2), repos.ImportOptions{Force: true}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmID_2, Message: "", Err: nil}, nil).Once()
-		target.On("Import", mock.Anything, model.MustParseTMID(tmID_3), utils.NormalizeLineEndings(tmContent3), repos.ImportOptions{}).
+		target.On("Import", mock.Anything, model.MustParseTMID(tmID_3), utils.NormalizeLineEndings(tmContent3), repos.ImportOptions{Force: true}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmID_3, Message: "", Err: nil}, nil).Once()
-		target.On("ImportAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), model.Attachment{Name: "README.md"}, readmeContent).Return(nil).Once()
-		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), model.Attachment{Name: "CHANGELOG.md"}, changelogContent).Return(nil).Once()
+		target.On("ImportAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), model.Attachment{Name: "README.md"}, readmeContent, true).Return(nil).Once()
+		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), model.Attachment{Name: "CHANGELOG.md"}, changelogContent, true).Return(nil).Once()
 		target.On("Index", mock.Anything, tmID_1, tmID_2, tmID_3).Return(nil)
 		target.On("Index", mock.Anything, tmID_1).Return(nil)
 		target.On("Index", mock.Anything, tmID_2).Return(nil)
 		target.On("Index", mock.Anything, tmID_3).Return(nil)
 
 		// when: copying from repo
-		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{})
+		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{Force: true})
 
 		// then: there is no error
 		assert.NoError(t, err)
@@ -234,7 +234,7 @@ func TestCopy(t *testing.T) {
 		// and then: all expectations on target mock are met
 	})
 
-	t.Run("with error pushing an attachment", func(t *testing.T) {
+	t.Run("with error importing an attachment", func(t *testing.T) {
 		// given: a repo having 1 ThingModel and 1 attachments and a target repo
 		sourceSpec := model.NewRepoSpec("r1")
 		targetSpec := model.NewRepoSpec("target")
@@ -251,7 +251,7 @@ func TestCopy(t *testing.T) {
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), "README.md").Return(readmeContent, nil).Once()
 		target.On("Import", mock.Anything, model.MustParseTMID(tmid), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid, Message: "", Err: nil}, nil).Once()
-		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), model.Attachment{Name: "README.md", MediaType: "text/markdown"}, readmeContent).Return(os.ErrPermission).Once()
+		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), model.Attachment{Name: "README.md", MediaType: "text/markdown"}, readmeContent, false).Return(os.ErrPermission).Once()
 		target.On("Index", mock.Anything, tmid).Return(nil).Twice()
 
 		// when: copying from repo

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -100,6 +100,10 @@ func HandleErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 		errTitle = Error400Title
 		errDetail = ErrorRepoAmbiguousDetail
 		errStatus = http.StatusBadRequest
+	case errors.Is(err, repos.ErrAttachmentExists):
+		errTitle = Error409Title
+		errDetail = err.Error()
+		errStatus = http.StatusConflict
 	// handle error values we want to access with errors.As()
 	case errors.As(err, &nfErr):
 		errTitle = Error404Title
@@ -210,6 +214,13 @@ func convertRepoName(repo *string) string {
 		return *repo
 	}
 	return ""
+}
+
+func convertForceParam(p *server.ForceImport) bool {
+	if p != nil {
+		return *p
+	}
+	return false
 }
 
 func convertParams(params any) *model.SearchParams {

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/wot-oss/tmc/internal/app/http/server"
@@ -171,10 +170,7 @@ func (h *TmcHandler) ImportThingModel(w http.ResponseWriter, r *http.Request, p 
 	}
 
 	opts := repos.ImportOptions{}
-	if p.Force != nil {
-		parsedForce, err := strconv.ParseBool(*p.Force)
-		opts.Force = parsedForce && err == nil
-	}
+	opts.Force = convertForceParam(p.Force)
 	if p.OptPath != nil {
 		opts.OptPath = *p.OptPath
 	}
@@ -365,15 +361,15 @@ func (h *TmcHandler) DeleteTMNameAttachment(w http.ResponseWriter, r *http.Reque
 
 func (h *TmcHandler) PutThingModelAttachmentByName(w http.ResponseWriter, r *http.Request, tmID string, attachmentFileName string, params server.PutThingModelAttachmentByNameParams) {
 	ref := model.NewTMIDAttachmentContainerRef(tmID)
-	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType))
+	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
 }
 
 func (h *TmcHandler) PutTMNameAttachment(w http.ResponseWriter, r *http.Request, tmName server.TMName, attachmentFileName server.AttachmentFileName, params server.PutTMNameAttachmentParams) {
 	ref := model.NewTMNameAttachmentContainerRef(tmName)
-	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType))
+	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), false)
 }
 
-func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, contentType string) {
+func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, contentType string, force bool) {
 	defer r.Body.Close()
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -385,7 +381,7 @@ func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, repo 
 		return
 	}
 
-	err = h.Service.ImportAttachment(r.Context(), repo, ref, attachmentFileName, b, contentType)
+	err = h.Service.ImportAttachment(r.Context(), repo, ref, attachmentFileName, b, contentType, force)
 	if err != nil {
 		HandleErrorResponse(w, r, err)
 		return

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -359,14 +359,14 @@ func (h *TmcHandler) DeleteTMNameAttachment(w http.ResponseWriter, r *http.Reque
 	h.deleteAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName)
 }
 
-func (h *TmcHandler) PutThingModelAttachmentByName(w http.ResponseWriter, r *http.Request, tmID string, attachmentFileName string, params server.PutThingModelAttachmentByNameParams) {
+func (h *TmcHandler) PutTMIDAttachment(w http.ResponseWriter, r *http.Request, tmID string, attachmentFileName string, params server.PutTMIDAttachmentParams) {
 	ref := model.NewTMIDAttachmentContainerRef(tmID)
 	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
 }
 
 func (h *TmcHandler) PutTMNameAttachment(w http.ResponseWriter, r *http.Request, tmName server.TMName, attachmentFileName server.AttachmentFileName, params server.PutTMNameAttachmentParams) {
 	ref := model.NewTMNameAttachmentContainerRef(tmName)
-	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), false)
+	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
 }
 
 func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, contentType string, force bool) {

--- a/internal/app/http/mocks/HandlerService.go
+++ b/internal/app/http/mocks/HandlerService.go
@@ -333,17 +333,17 @@ func (_m *HandlerService) GetTMMetadata(ctx context.Context, repo string, tmID s
 	return r0, r1
 }
 
-// ImportAttachment provides a mock function with given fields: ctx, repo, ref, attachmentFileName, content, contentType
-func (_m *HandlerService) ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string) error {
-	ret := _m.Called(ctx, repo, ref, attachmentFileName, content, contentType)
+// ImportAttachment provides a mock function with given fields: ctx, repo, ref, attachmentFileName, content, contentType, force
+func (_m *HandlerService) ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string, force bool) error {
+	ret := _m.Called(ctx, repo, ref, attachmentFileName, content, contentType, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ImportAttachment")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, model.AttachmentContainerRef, string, []byte, string) error); ok {
-		r0 = rf(ctx, repo, ref, attachmentFileName, content, contentType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.AttachmentContainerRef, string, []byte, string, bool) error); ok {
+		r0 = rf(ctx, repo, ref, attachmentFileName, content, contentType, force)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/app/http/server/models.gen.go
+++ b/internal/app/http/server/models.gen.go
@@ -379,8 +379,8 @@ type GetThingModelAttachmentByNameParams struct {
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
-// PutThingModelAttachmentByNameParams defines parameters for PutThingModelAttachmentByName.
-type PutThingModelAttachmentByNameParams struct {
+// PutTMIDAttachmentParams defines parameters for PutTMIDAttachment.
+type PutTMIDAttachmentParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 

--- a/internal/app/http/server/models.gen.go
+++ b/internal/app/http/server/models.gen.go
@@ -177,6 +177,9 @@ type AttachmentFileName = string
 // FetchName defines model for FetchName.
 type FetchName = string
 
+// ForceImport defines model for ForceImport.
+type ForceImport = bool
+
 // RepoConstraint defines model for RepoConstraint.
 type RepoConstraint = string
 
@@ -309,8 +312,8 @@ type ImportThingModelParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 
-	// Force flag to force the import, ignoring any conflicts with existing TMs
-	Force *string `form:"force,omitempty" json:"force,omitempty"`
+	// Force flag to force the import, ignoring any conflicts with existing data
+	Force *ForceImport `form:"force,omitempty" json:"force,omitempty"`
 
 	// OptPath optional path parts to append to the target path (and id) of imported TM, after the mandatory path structure
 	OptPath *string `form:"optPath,omitempty" json:"optPath,omitempty"`
@@ -341,6 +344,9 @@ type GetTMNameAttachmentParams struct {
 type PutTMNameAttachmentParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// Force flag to force the import, ignoring any conflicts with existing data
+	Force *ForceImport `form:"force,omitempty" json:"force,omitempty"`
 }
 
 // DeleteThingModelByIdParams defines parameters for DeleteThingModelById.
@@ -377,6 +383,9 @@ type GetThingModelAttachmentByNameParams struct {
 type PutThingModelAttachmentByNameParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// Force flag to force the import, ignoring any conflicts with existing data
+	Force *ForceImport `form:"force,omitempty" json:"force,omitempty"`
 }
 
 // ImportThingModelJSONRequestBody defines body for ImportThingModel for application/json ContentType.

--- a/internal/app/http/server/server.gen.go
+++ b/internal/app/http/server/server.gen.go
@@ -82,7 +82,7 @@ type ServerInterface interface {
 	GetThingModelAttachmentByName(w http.ResponseWriter, r *http.Request, tmID TMID, attachmentFileName AttachmentFileName, params GetThingModelAttachmentByNameParams)
 	// Upload an attachment to a Thing Model
 	// (PUT /thing-models/{tmID}/.attachments/{attachmentFileName})
-	PutThingModelAttachmentByName(w http.ResponseWriter, r *http.Request, tmID TMID, attachmentFileName AttachmentFileName, params PutThingModelAttachmentByNameParams)
+	PutTMIDAttachment(w http.ResponseWriter, r *http.Request, tmID TMID, attachmentFileName AttachmentFileName, params PutTMIDAttachmentParams)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -984,8 +984,8 @@ func (siw *ServerInterfaceWrapper) GetThingModelAttachmentByName(w http.Response
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// PutThingModelAttachmentByName operation middleware
-func (siw *ServerInterfaceWrapper) PutThingModelAttachmentByName(w http.ResponseWriter, r *http.Request) {
+// PutTMIDAttachment operation middleware
+func (siw *ServerInterfaceWrapper) PutTMIDAttachment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
@@ -1011,7 +1011,7 @@ func (siw *ServerInterfaceWrapper) PutThingModelAttachmentByName(w http.Response
 	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params PutThingModelAttachmentByNameParams
+	var params PutTMIDAttachmentParams
 
 	// ------------- Optional query parameter "repo" -------------
 
@@ -1030,7 +1030,7 @@ func (siw *ServerInterfaceWrapper) PutThingModelAttachmentByName(w http.Response
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PutThingModelAttachmentByName(w, r, tmID, attachmentFileName, params)
+		siw.Handler.PutTMIDAttachment(w, r, tmID, attachmentFileName, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1159,7 +1159,7 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 
 	r.HandleFunc(options.BaseURL+"/thing-models/.tmName/{tmName:.+}/.attachments/{attachmentFileName:.+}", wrapper.DeleteTMNameAttachment).Methods("DELETE")
 
-	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.PutThingModelAttachmentByName).Methods("PUT")
+	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.PutTMIDAttachment).Methods("PUT")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.GetThingModelAttachmentByName).Methods("GET")
 

--- a/internal/app/http/server/server.gen.go
+++ b/internal/app/http/server/server.gen.go
@@ -768,6 +768,14 @@ func (siw *ServerInterfaceWrapper) PutTMNameAttachment(w http.ResponseWriter, r 
 		return
 	}
 
+	// ------------- Optional query parameter "force" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "force", r.URL.Query(), &params.Force)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "force", Err: err})
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PutTMNameAttachment(w, r, tmName, attachmentFileName, params)
 	}))
@@ -1010,6 +1018,14 @@ func (siw *ServerInterfaceWrapper) PutThingModelAttachmentByName(w http.Response
 	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "force" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "force", r.URL.Query(), &params.Force)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "force", Err: err})
 		return
 	}
 

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/wot-oss/tmc/internal/commands"
 	"github.com/wot-oss/tmc/internal/model"
 	"github.com/wot-oss/tmc/internal/repos"
-	"github.com/wot-oss/tmc/internal/utils"
 )
 
 //go:generate mockery --name HandlerService --outpkg mocks --output mocks
@@ -33,7 +32,7 @@ type HandlerService interface {
 	GetTMMetadata(ctx context.Context, repo string, tmID string) ([]model.FoundVersion, error)
 	GetLatestTMMetadata(ctx context.Context, repo string, fetchName string) (model.FoundVersion, error)
 	FetchAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string) ([]byte, error)
-	ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string) error
+	ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string, force bool) error
 	DeleteAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string) error
 	ListRepos(ctx context.Context) ([]model.RepoDescription, error)
 }
@@ -281,15 +280,15 @@ func (dhs *defaultHandlerService) DeleteAttachment(ctx context.Context, repo str
 	err = commands.DeleteAttachment(ctx, spec, ref, attachmentFileName)
 	return err
 }
-func (dhs *defaultHandlerService) ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string) error {
+func (dhs *defaultHandlerService) ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string, force bool) error {
 	spec, err := dhs.inferTargetRepo(ctx, repo)
 	if err != nil {
 		return err
 	}
 	err = commands.ImportAttachment(ctx, spec, ref, model.Attachment{
 		Name:      attachmentFileName,
-		MediaType: utils.DetectMediaType(contentType, attachmentFileName, utils.ReadCloserGetterFromBytes(content)),
-	}, content)
+		MediaType: contentType,
+	}, content, force)
 	return err
 }
 

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"slices"
@@ -289,7 +288,7 @@ func (dhs *defaultHandlerService) ImportAttachment(ctx context.Context, repo str
 	}
 	err = commands.ImportAttachment(ctx, spec, ref, model.Attachment{
 		Name:      attachmentFileName,
-		MediaType: utils.DetectMediaType(contentType, attachmentFileName, bytes.NewBuffer(content)),
+		MediaType: utils.DetectMediaType(contentType, attachmentFileName, utils.ReadCloserGetterFromBytes(content)),
 	}, content)
 	return err
 }

--- a/internal/app/http/service_test.go
+++ b/internal/app/http/service_test.go
@@ -648,12 +648,12 @@ func TestService_ImportAttachment(t *testing.T) {
 	r := mocks.NewRepo(t)
 	r.On("ImportAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), model.Attachment{
 		Name:      attName,
-		MediaType: "text/plain; charset=utf-8",
-	}, attContent).Return(nil).Once()
+		MediaType: "text/markdown",
+	}, attContent, true).Return(nil).Once()
 	rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, repo, r, nil))
 	rMocks.MockReposGetDescriptions(t, []model.RepoDescription{{Name: "someRepo"}}, nil)
 	// when: pushing an attachment
-	err := underTest.ImportAttachment(context.Background(), "someRepo", model.NewTMNameAttachmentContainerRef(inventoryName), attName, attContent, "")
+	err := underTest.ImportAttachment(context.Background(), "someRepo", model.NewTMNameAttachmentContainerRef(inventoryName), attName, attContent, "text/markdown", true)
 	// then: service returns no error
 	assert.NoError(t, err)
 }

--- a/internal/commands/attachment.go
+++ b/internal/commands/attachment.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wot-oss/tmc/internal/repos"
 )
 
-func ImportAttachment(ctx context.Context, spec model.RepoSpec, ref model.AttachmentContainerRef, att model.Attachment, content []byte) error {
+func ImportAttachment(ctx context.Context, spec model.RepoSpec, ref model.AttachmentContainerRef, att model.Attachment, content []byte, force bool) error {
 	repo, err := repos.Get(spec)
 	if err != nil {
 		return fmt.Errorf("Could not ìnitialize a repo instance for %s: %w\ncheck config", spec, err)
@@ -18,7 +18,7 @@ func ImportAttachment(ctx context.Context, spec model.RepoSpec, ref model.Attach
 
 	sanitizedAttachmentName := strings.ReplaceAll(filepath.ToSlash(filepath.Clean(att.Name)), "/", "-")
 	sanitizedAtt := model.Attachment{Name: sanitizedAttachmentName, MediaType: att.MediaType}
-	err = repo.ImportAttachment(ctx, ref, sanitizedAtt, content)
+	err = repo.ImportAttachment(ctx, ref, sanitizedAtt, content, force)
 	return err
 }
 

--- a/internal/repos/errors.go
+++ b/internal/repos/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrRepoNotFound            = errors.New("repo not found")
 	ErrInvalidRepoName         = errors.New("invalid repo name")
 	ErrRepoExists              = errors.New("named repo already exists")
+	ErrAttachmentExists        = errors.New("attachment already exists")
 	ErrInvalidErrorCode        = errors.New("invalid error code")
 	ErrInvalidCompletionParams = errors.New("invalid completion parameters")
 	ErrNotSupported            = errors.New("method not supported")

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -907,7 +907,7 @@ func TestFileRepo_ImportAttachment(t *testing.T) {
 	r2Content := []byte("# read this, too")
 	t.Run("tm name attachment without media type provided", func(t *testing.T) {
 		ref := model.NewTMNameAttachmentContainerRef(tmName)
-		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name}, r2Content)
+		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name}, r2Content, false)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(temp, tmName, model.AttachmentsDir, r2Name))
 		index, err := r.readIndex()
@@ -920,7 +920,7 @@ func TestFileRepo_ImportAttachment(t *testing.T) {
 	})
 	t.Run("tm name attachment with media type", func(t *testing.T) {
 		ref := model.NewTMNameAttachmentContainerRef(tmName)
-		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/html"}, r2Content)
+		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/html"}, r2Content, true)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(temp, tmName, model.AttachmentsDir, r2Name))
 		index, err := r.readIndex()
@@ -933,7 +933,7 @@ func TestFileRepo_ImportAttachment(t *testing.T) {
 	})
 	t.Run("tm id attachment with media type provided by user", func(t *testing.T) {
 		ref := model.NewTMIDAttachmentContainerRef(id)
-		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/markdown"}, r2Content)
+		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/markdown"}, r2Content, false)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(temp, tmName, model.AttachmentsDir, ver, r2Name))
 		index, err := r.readIndex()
@@ -946,7 +946,7 @@ func TestFileRepo_ImportAttachment(t *testing.T) {
 	})
 	t.Run("tm id attachment without media type", func(t *testing.T) {
 		ref := model.NewTMIDAttachmentContainerRef(id)
-		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/markdown"}, r2Content)
+		err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: r2Name, MediaType: "text/markdown"}, r2Content, true)
 		assert.NoError(t, err)
 		assert.FileExists(t, filepath.Join(temp, tmName, model.AttachmentsDir, ver, r2Name))
 		index, err := r.readIndex()
@@ -957,20 +957,24 @@ func TestFileRepo_ImportAttachment(t *testing.T) {
 			assert.Equal(t, "text/markdown", att.MediaType)
 		}
 	})
+	t.Run("tm id attachment conflict", func(t *testing.T) {
+		err := r.ImportAttachment(context.Background(), model.NewTMIDAttachmentContainerRef(id), model.Attachment{Name: r2Name}, r2Content, false)
+		assert.ErrorIs(t, err, ErrAttachmentExists)
+	})
 	t.Run("non existent tm name", func(t *testing.T) {
-		err := r.ImportAttachment(context.Background(), model.NewTMNameAttachmentContainerRef("omnicorp-tm-department/omnicorp/omnidarkness"), model.Attachment{Name: r2Name}, r2Content)
+		err := r.ImportAttachment(context.Background(), model.NewTMNameAttachmentContainerRef("omnicorp-tm-department/omnicorp/omnidarkness"), model.Attachment{Name: r2Name}, r2Content, false)
 		assert.ErrorIs(t, err, model.ErrTMNameNotFound)
 	})
 	t.Run("non existent tm id", func(t *testing.T) {
-		err := r.ImportAttachment(context.Background(), model.NewTMIDAttachmentContainerRef(tmName+"/v1.2.3-20240409155220-3f779458e453.tm.json"), model.Attachment{Name: r2Name}, r2Content)
+		err := r.ImportAttachment(context.Background(), model.NewTMIDAttachmentContainerRef(tmName+"/v1.2.3-20240409155220-3f779458e453.tm.json"), model.Attachment{Name: r2Name}, r2Content, false)
 		assert.ErrorIs(t, err, model.ErrTMNotFound)
 	})
 	t.Run("invalid tm name", func(t *testing.T) {
-		err := r.ImportAttachment(context.Background(), model.NewTMNameAttachmentContainerRef("omnicorp-tm-departmentomnicorp/omnilamp"), model.Attachment{Name: r2Name}, r2Content)
+		err := r.ImportAttachment(context.Background(), model.NewTMNameAttachmentContainerRef("omnicorp-tm-departmentomnicorp/omnilamp"), model.Attachment{Name: r2Name}, r2Content, false)
 		assert.ErrorIs(t, err, model.ErrInvalidIdOrName)
 	})
 	t.Run("invalid tm id", func(t *testing.T) {
-		err := r.ImportAttachment(context.Background(), model.NewTMIDAttachmentContainerRef(tmName+"/v1.2.3-20240409155220-3f779458e453"), model.Attachment{Name: r2Name}, r2Content)
+		err := r.ImportAttachment(context.Background(), model.NewTMIDAttachmentContainerRef(tmName+"/v1.2.3-20240409155220-3f779458e453"), model.Attachment{Name: r2Name}, r2Content, false)
 		assert.ErrorIs(t, err, model.ErrInvalidId)
 	})
 }

--- a/internal/repos/http.go
+++ b/internal/repos/http.go
@@ -233,7 +233,7 @@ func (h *HttpRepo) GetTMMetadata(ctx context.Context, tmID string) ([]model.Foun
 	return []model.FoundVersion{fv}, nil
 }
 
-func (h *HttpRepo) ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte) error {
+func (h *HttpRepo) ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte, force bool) error {
 	return ErrNotSupported
 }
 

--- a/internal/repos/mocks/Repo.go
+++ b/internal/repos/mocks/Repo.go
@@ -195,17 +195,17 @@ func (_m *Repo) Import(ctx context.Context, id model.TMID, raw []byte, opts repo
 	return r0, r1
 }
 
-// ImportAttachment provides a mock function with given fields: ctx, container, attachment, content
-func (_m *Repo) ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte) error {
-	ret := _m.Called(ctx, container, attachment, content)
+// ImportAttachment provides a mock function with given fields: ctx, container, attachment, content, force
+func (_m *Repo) ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte, force bool) error {
+	ret := _m.Called(ctx, container, attachment, content, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ImportAttachment")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.AttachmentContainerRef, model.Attachment, []byte) error); ok {
-		r0 = rf(ctx, container, attachment, content)
+	if rf, ok := ret.Get(0).(func(context.Context, model.AttachmentContainerRef, model.Attachment, []byte, bool) error); ok {
+		r0 = rf(ctx, container, attachment, content, force)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -117,7 +117,7 @@ type Repo interface {
 	ListCompletions(ctx context.Context, kind string, args []string, toComplete string) ([]string, error)
 
 	GetTMMetadata(ctx context.Context, tmID string) ([]model.FoundVersion, error)
-	ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte) error
+	ImportAttachment(ctx context.Context, container model.AttachmentContainerRef, attachment model.Attachment, content []byte, force bool) error
 	FetchAttachment(ctx context.Context, container model.AttachmentContainerRef, attachmentName string) ([]byte, error)
 	DeleteAttachment(ctx context.Context, container model.AttachmentContainerRef, attachmentName string) error
 }

--- a/internal/repos/tmc_test.go
+++ b/internal/repos/tmc_test.go
@@ -584,7 +584,7 @@ func TestTmcRepo_DeleteAttachment(t *testing.T) {
 		})
 	}
 }
-func TestTmcRepo_PushAttachment(t *testing.T) {
+func TestTmcRepo_ImportAttachment(t *testing.T) {
 	type ht struct {
 		name    string
 		body    []byte
@@ -670,6 +670,15 @@ func TestTmcRepo_PushAttachment(t *testing.T) {
 			reqBody: []byte("# README"),
 		},
 		{
+			name:    "attachment exists",
+			body:    []byte(`{"detail":"attachment already exists"}`),
+			status:  http.StatusConflict,
+			tmName:  "author/manufacturer/mpn",
+			expUrl:  "/thing-models/.tmName/author/manufacturer/mpn/.attachments/README.md",
+			expErr:  "attachment already exists",
+			reqBody: []byte("# README"),
+		},
+		{
 			name:    "unexpected status",
 			body:    []byte(`{"detail":"no coffee for you"}`),
 			status:  http.StatusTeapot,
@@ -689,7 +698,7 @@ func TestTmcRepo_PushAttachment(t *testing.T) {
 			} else {
 				ref = model.NewTMNameAttachmentContainerRef(test.tmName)
 			}
-			err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: "README.md"}, test.reqBody)
+			err := r.ImportAttachment(context.Background(), ref, model.Attachment{Name: "README.md"}, test.reqBody, false)
 			if test.expErr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -270,7 +270,7 @@ func ReadCloserGetterFromFilename(name string) ReadCloserGetter {
 }
 
 // DetectMediaType detects the media type of the file. The type provided by the user always takes precedence over
-// automatic detection, unless it is empty. The type is detected by http.DetectContenType. If that returns the
+// automatic detection, unless it is empty. The type is detected by http.DetectContentType. If that returns the
 // generic 'application/octet-stream', then the type is guessed from the filename extension.
 // If all of the above fails, it returns 'application/octet-stream'
 func DetectMediaType(userGivenType string, filename string, getReader ReadCloserGetter) string {


### PR DESCRIPTION
feat: return error on attachment import when it already exists and add a flag to override