### PR TITLE
chore: minor improvements

### DIFF
--- a/cmd/completion/complete.go
+++ b/cmd/completion/complete.go
@@ -59,7 +59,7 @@ func getRepo(cmd *cobra.Command) (*repos.Union, error) {
 		return nil, err
 	}
 
-	u, err := repos.GetSpecdOrAll(spec)
+	u, err := repos.GetUnion(spec)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/adr/adr002-dont-infer-repo-type-from-uri-scheme.md
+++ b/docs/adr/adr002-dont-infer-repo-type-from-uri-scheme.md
@@ -1,0 +1,34 @@
+# Why We Don’t Derive Repo Types from URI Schemes
+
+## Status
+
+accepted
+
+## Context
+
+A question repeatedly comes up in discussions why don't we use URI scheme to define the type of repository instead of making user specify the type explicitly. 
+An example of a seemingly useful scheme is 'tmc' to define a repository based on a remote instance of our own API. 
+
+This ADR records the reasons for why we don't do that.
+
+## Decision
+
+List of reasons in no particular order:
+
+1. W3C discourages creating new URI schemes, especially private schemes, not registered with IANA. 
+See references [1] and [2]
+2. Even for a single repo type 'tmc', one URI scheme would not be enough. 
+We would need at least to define a TLS variant of the same scheme, like 'tmcs' or 'tmc+tls'.
+3. After a user started our API with `tmc serve` she would need to differentiate between URIs used to access the
+API from a browser or a REST client like Postman ("http://thingmodels.example.com") and from another tmc CLI 
+("tmc://thingmodels.example.com").
+4. If we ever decide to offer another API, e.g. gRPC, that would confuse the matters even more as it would require some 
+kind of differentiation in the repo config between the REST API and a gRPC API types.
+
+## Consequences
+
+We will continue to require specifying repo type independently of URI scheme.
+
+
+[1]: https://www.w3.org/wiki/UriSchemes
+[2]: http://infomesh.net/2001/09/urischemes

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -213,11 +213,11 @@ func (dhs *defaultHandlerService) DeleteThingModel(ctx context.Context, repo str
 }
 
 func (dhs *defaultHandlerService) GetCompletions(ctx context.Context, kind string, args []string, toComplete string) ([]string, error) {
-	rs, err := repos.GetUnion(dhs.serveRepo)
+	u, err := repos.GetUnion(dhs.serveRepo)
 	if err != nil {
 		return nil, err
 	}
-	return rs.ListCompletions(ctx, kind, args, toComplete), nil
+	return u.ListCompletions(ctx, kind, args, toComplete), nil
 }
 
 func (dhs *defaultHandlerService) GetTMMetadata(ctx context.Context, repo string, tmID string) ([]model.FoundVersion, error) {

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -213,7 +213,7 @@ func (dhs *defaultHandlerService) DeleteThingModel(ctx context.Context, repo str
 }
 
 func (dhs *defaultHandlerService) GetCompletions(ctx context.Context, kind string, args []string, toComplete string) ([]string, error) {
-	rs, err := repos.GetSpecdOrAll(dhs.serveRepo)
+	rs, err := repos.GetUnion(dhs.serveRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (dhs *defaultHandlerService) CheckHealthLive(ctx context.Context) error {
 
 func (dhs *defaultHandlerService) CheckHealthReady(ctx context.Context) error {
 
-	_, err := repos.GetSpecdOrAll(dhs.serveRepo)
+	_, err := repos.GetUnion(dhs.serveRepo)
 	if err != nil {
 		return errors.New("invalid repo configuration or ")
 	}

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -200,12 +200,8 @@ func findMostRecentMatchingVersion(versions []model.FoundVersion, ver string) (i
 // sortFoundVersionsDesc sorts by semver then timestamp in descending order, ie. from newest to oldest
 func sortFoundVersionsDesc(versions []model.FoundVersion) {
 	slices.SortStableFunc(versions, func(a, b model.FoundVersion) int {
-		av := semver.MustParse(a.Version.Model)
-		bv := semver.MustParse(b.Version.Model)
-		vc := bv.Compare(av)
-		if vc != 0 {
-			return vc
-		}
-		return strings.Compare(b.TimeStamp, a.TimeStamp) // our timestamps can be compared lexicographically
+		aid, _ := model.ParseTMID(a.TMID)
+		bid, _ := model.ParseTMID(b.TMID)
+		return -aid.Version.Compare(bid.Version)
 	})
 }

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -27,12 +27,12 @@ func FetchByTMIDOrName(ctx context.Context, spec model.RepoSpec, idOrName string
 }
 
 func FetchByTMID(ctx context.Context, spec model.RepoSpec, tmid string, restoreId bool) (string, []byte, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetUnion(spec)
+	u, err := repos.GetUnion(spec)
 	if err != nil {
 		return "", nil, err, nil
 	}
 
-	fetch, bytes, err, accessErrors := rs.Fetch(ctx, tmid)
+	fetch, bytes, err, accessErrors := u.Fetch(ctx, tmid)
 	if err == nil && restoreId {
 		bytes = restoreExternalId(bytes)
 	}
@@ -146,8 +146,6 @@ func findMostRecentVersion(versions []model.FoundVersion) (string, model.RepoSpe
 		return "", model.EmptySpec, err
 	}
 
-	sortFoundVersionsDesc(versions)
-
 	v := versions[0]
 	return v.TMID, model.NewSpecFromFoundSource(v.FoundIn), nil
 }
@@ -189,19 +187,7 @@ func findMostRecentMatchingVersion(versions []model.FoundVersion, ver string) (i
 		return "", model.EmptySpec, err
 	}
 
-	// sort the remaining by semver then timestamp in descending order
-	sortFoundVersionsDesc(versions)
-
 	// and here's our winner
 	v := versions[0]
 	return v.TMID, model.NewSpecFromFoundSource(v.FoundIn), nil
-}
-
-// sortFoundVersionsDesc sorts by semver then timestamp in descending order, ie. from newest to oldest
-func sortFoundVersionsDesc(versions []model.FoundVersion) {
-	slices.SortStableFunc(versions, func(a, b model.FoundVersion) int {
-		aid, _ := model.ParseTMID(a.TMID)
-		bid, _ := model.ParseTMID(b.TMID)
-		return -aid.Version.Compare(bid.Version)
-	})
 }

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -27,7 +27,7 @@ func FetchByTMIDOrName(ctx context.Context, spec model.RepoSpec, idOrName string
 }
 
 func FetchByTMID(ctx context.Context, spec model.RepoSpec, tmid string, restoreId bool) (string, []byte, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetSpecdOrAll(spec)
+	rs, err := repos.GetUnion(spec)
 	if err != nil {
 		return "", nil, err, nil
 	}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -8,7 +8,7 @@ import (
 )
 
 func List(ctx context.Context, rSpec model.RepoSpec, search *model.SearchParams) (model.SearchResult, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetSpecdOrAll(rSpec)
+	rs, err := repos.GetUnion(rSpec)
 	if err != nil {
 		return model.SearchResult{}, err, nil
 	}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -8,10 +8,10 @@ import (
 )
 
 func List(ctx context.Context, rSpec model.RepoSpec, search *model.SearchParams) (model.SearchResult, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetUnion(rSpec)
+	u, err := repos.GetUnion(rSpec)
 	if err != nil {
 		return model.SearchResult{}, err, nil
 	}
-	sr, errs := rs.List(ctx, search)
+	sr, errs := u.List(ctx, search)
 	return sr, nil, errs
 }

--- a/internal/commands/tmmeta.go
+++ b/internal/commands/tmmeta.go
@@ -8,11 +8,11 @@ import (
 )
 
 func GetTMMetadata(ctx context.Context, spec model.RepoSpec, tmID string) ([]model.FoundVersion, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetUnion(spec)
+	u, err := repos.GetUnion(spec)
 	if err != nil {
 		return nil, err, nil
 	}
 
-	sr, errs := rs.GetTMMetadata(ctx, tmID)
+	sr, errs := u.GetTMMetadata(ctx, tmID)
 	return sr, nil, errs
 }

--- a/internal/commands/tmmeta.go
+++ b/internal/commands/tmmeta.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GetTMMetadata(ctx context.Context, spec model.RepoSpec, tmID string) ([]model.FoundVersion, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetSpecdOrAll(spec)
+	rs, err := repos.GetUnion(spec)
 	if err != nil {
 		return nil, err, nil
 	}

--- a/internal/commands/versions.go
+++ b/internal/commands/versions.go
@@ -14,10 +14,10 @@ func NewVersionsCommand() *VersionsCommand {
 	return &VersionsCommand{}
 }
 func (c *VersionsCommand) ListVersions(ctx context.Context, spec model.RepoSpec, name string) ([]model.FoundVersion, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetUnion(spec)
+	u, err := repos.GetUnion(spec)
 	if err != nil {
 		return nil, err, nil
 	}
-	versions, errors := rs.Versions(ctx, name)
+	versions, errors := u.Versions(ctx, name)
 	return versions, nil, errors
 }

--- a/internal/commands/versions.go
+++ b/internal/commands/versions.go
@@ -14,7 +14,7 @@ func NewVersionsCommand() *VersionsCommand {
 	return &VersionsCommand{}
 }
 func (c *VersionsCommand) ListVersions(ctx context.Context, spec model.RepoSpec, name string) ([]model.FoundVersion, error, []*repos.RepoAccessError) {
-	rs, err := repos.GetSpecdOrAll(spec)
+	rs, err := repos.GetUnion(spec)
 	if err != nil {
 		return nil, err, nil
 	}

--- a/internal/commands/versions_test.go
+++ b/internal/commands/versions_test.go
@@ -56,8 +56,8 @@ func TestVersionsCommand_ListVersions(t *testing.T) {
 		assert.Len(t, res, 4)
 		assert.Equal(t, []model.FoundVersion{
 			{
-				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json"},
-				FoundIn:      model.FoundSource{RepoName: "r2"},
+				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
+				FoundIn:      model.FoundSource{RepoName: "r1"},
 			},
 			{
 				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json"},
@@ -68,8 +68,8 @@ func TestVersionsCommand_ListVersions(t *testing.T) {
 				FoundIn:      model.FoundSource{RepoName: "r1"},
 			},
 			{
-				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
-				FoundIn:      model.FoundSource{RepoName: "r1"},
+				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json"},
+				FoundIn:      model.FoundSource{RepoName: "r2"},
 			},
 		}, res)
 
@@ -106,11 +106,11 @@ func TestVersionsCommand_ListVersions(t *testing.T) {
 		assert.Len(t, res, 2)
 		assert.Equal(t, []model.FoundVersion{
 			{
-				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json"},
+				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
 				FoundIn:      model.FoundSource{RepoName: "r1"},
 			},
 			{
-				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
+				IndexVersion: &model.IndexVersion{TMID: "murphy/omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json"},
 				FoundIn:      model.FoundSource{RepoName: "r1"},
 			},
 		}, res)

--- a/internal/model/id.go
+++ b/internal/model/id.go
@@ -71,6 +71,18 @@ func (v TMVersion) BaseString() string {
 	return res
 }
 
+func (v TMVersion) Compare(other TMVersion) int {
+	vc := v.Base.Compare(other.Base)
+	if vc != 0 {
+		return vc
+	}
+	tc := strings.Compare(v.Timestamp, other.Timestamp) // our timestamps can be compared lexicographically
+	if tc != 0 {
+		return tc
+	}
+	return strings.Compare(v.Hash, other.Hash) // there's no sense in comparing hashes other that to ensure a stable order
+}
+
 func (id TMID) String() string {
 	return fmt.Sprintf("%s/%s%s", id.Name, id.Version, TMFileExtension)
 }

--- a/internal/model/search.go
+++ b/internal/model/search.go
@@ -52,15 +52,13 @@ func MergeFoundVersions(vs1, vs2 []FoundVersion) []FoundVersion {
 	slices.SortStableFunc(vs1, func(a, b FoundVersion) int {
 		tmid1, _ := ParseTMID(a.TMID)
 		tmid2, _ := ParseTMID(b.TMID)
-		if tmid1.Equals(tmid2) {
-			tc := strings.Compare(tmid1.Version.Timestamp, tmid2.Version.Timestamp)
-			if tc != 0 {
-				return -tc // sort in reverse chronological order within the same TMID
-			}
+		nc := strings.Compare(tmid1.Name, tmid2.Name)
+		if nc != 0 {
+			return nc
 		}
-		ic := strings.Compare(a.TMID, b.TMID)
-		if ic != 0 {
-			return ic
+		vc := -tmid1.Version.Compare(tmid2.Version) // sort in descending order within the same TM name
+		if vc != 0 {
+			return vc
 		}
 		return strings.Compare(a.FoundIn.RepoName, b.FoundIn.RepoName)
 	})

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/wot-oss/tmc/internal/utils"
 )
 
@@ -155,18 +154,10 @@ func (idx *Index) Sort() {
 	}
 	// sort versions of each entry descending
 	for _, entry := range idx.Data {
-		slices.SortFunc(entry.Versions, func(a *IndexVersion, b *IndexVersion) int {
-			av := semver.MustParse(a.Version.Model)
-			bv := semver.MustParse(b.Version.Model)
-			vc := bv.Compare(av)
-			if vc != 0 {
-				return vc
-			}
-			vc = strings.Compare(b.TimeStamp, a.TimeStamp) // our timestamps can be compared lexicographically
-			if vc != 0 {
-				return vc
-			}
-			return strings.Compare(b.TMID, a.TMID) // in case of semVer and timestamp equality, use complete ID to ensure stable order
+		slices.SortStableFunc(entry.Versions, func(a, b *IndexVersion) int {
+			aid, _ := ParseTMID(a.TMID)
+			bid, _ := ParseTMID(b.TMID)
+			return -aid.Version.Compare(bid.Version)
 		})
 	}
 	// sort entries ascending

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -243,8 +242,8 @@ func findTMFileEntriesByBaseVersion(entries []os.DirEntry, version model.TMVersi
 			res = append(res, ver)
 		}
 	}
-	sort.Slice(res, func(i, j int) bool {
-		return strings.Compare(res[i].String(), res[j].String()) > 0
+	slices.SortStableFunc(res, func(a, b model.TMVersion) int {
+		return a.Compare(b)
 	})
 	return res
 }
@@ -339,6 +338,7 @@ func (f *FileRepo) List(ctx context.Context, search *model.SearchParams) (model.
 		return model.SearchResult{}, err
 	}
 	idx.Filter(search)
+	idx.Sort() // the index is supposed to be sorted on disk, but we don't trust external storage, hence we'll sort here one more time to be extra sure
 	return model.NewIndexToFoundMapper(f.Spec().ToFoundSource()).ToSearchResult(*idx), nil
 }
 

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -430,8 +430,8 @@ func AsRepoConfig(bytes []byte) (map[string]any, error) {
 	return rc, nil
 }
 
-// GetSpecdOrAll returns a union containing the repo specified by spec, or union of all repo, if the spec is empty
-func GetSpecdOrAll(spec model.RepoSpec) (*Union, error) {
+// GetUnion returns a union containing the repo specified by spec, or a union of all repos, if the spec is empty
+func GetUnion(spec model.RepoSpec) (*Union, error) {
 	if spec.RepoName() != "" || spec.Dir() != "" {
 		repo, err := Get(spec)
 		if err != nil {

--- a/internal/repos/repo_test.go
+++ b/internal/repos/repo_test.go
@@ -324,10 +324,10 @@ func TestGetSpecdOrAll(t *testing.T) {
 	})
 
 	// check if all repos are returned, when passing EmptySpec
-	all, err := GetUnion(model.EmptySpec)
+	u, err := GetUnion(model.EmptySpec)
 	assert.NoError(t, err)
 	expLocs := []string{"somewhere", "somewhere-else"}
-	for _, r := range all.rs {
+	for _, r := range u.rs {
 		if fr, ok := r.(*FileRepo); assert.True(t, ok) {
 			idx := slices.IndexFunc(expLocs, func(s string) bool { return s == fr.root })
 			if assert.Greater(t, idx, -1) {
@@ -337,19 +337,19 @@ func TestGetSpecdOrAll(t *testing.T) {
 	}
 	assert.Len(t, expLocs, 0) // no locations remained that were not found
 
-	all, err = GetUnion(model.NewRepoSpec("r1"))
+	u, err = GetUnion(model.NewRepoSpec("r1"))
 	assert.NoError(t, err)
-	if assert.Len(t, all.rs, 1) {
-		if r1, ok := all.rs[0].(*FileRepo); assert.True(t, ok) {
+	if assert.Len(t, u.rs, 1) {
+		if r1, ok := u.rs[0].(*FileRepo); assert.True(t, ok) {
 			assert.Equal(t, "somewhere", r1.root)
 		}
 	}
 
 	// get local repo
-	all, err = GetUnion(model.NewDirSpec("dir1"))
+	u, err = GetUnion(model.NewDirSpec("dir1"))
 	assert.NoError(t, err)
-	if assert.Len(t, all.rs, 1) {
-		if r1, ok := all.rs[0].(*FileRepo); assert.True(t, ok) {
+	if assert.Len(t, u.rs, 1) {
+		if r1, ok := u.rs[0].(*FileRepo); assert.True(t, ok) {
 			assert.Equal(t, "dir1", r1.root)
 		}
 	}

--- a/internal/repos/repo_test.go
+++ b/internal/repos/repo_test.go
@@ -324,7 +324,7 @@ func TestGetSpecdOrAll(t *testing.T) {
 	})
 
 	// check if all repos are returned, when passing EmptySpec
-	all, err := GetSpecdOrAll(model.EmptySpec)
+	all, err := GetUnion(model.EmptySpec)
 	assert.NoError(t, err)
 	expLocs := []string{"somewhere", "somewhere-else"}
 	for _, r := range all.rs {
@@ -337,7 +337,7 @@ func TestGetSpecdOrAll(t *testing.T) {
 	}
 	assert.Len(t, expLocs, 0) // no locations remained that were not found
 
-	all, err = GetSpecdOrAll(model.NewRepoSpec("r1"))
+	all, err = GetUnion(model.NewRepoSpec("r1"))
 	assert.NoError(t, err)
 	if assert.Len(t, all.rs, 1) {
 		if r1, ok := all.rs[0].(*FileRepo); assert.True(t, ok) {
@@ -346,7 +346,7 @@ func TestGetSpecdOrAll(t *testing.T) {
 	}
 
 	// get local repo
-	all, err = GetSpecdOrAll(model.NewDirSpec("dir1"))
+	all, err = GetUnion(model.NewDirSpec("dir1"))
 	assert.NoError(t, err)
 	if assert.Len(t, all.rs, 1) {
 		if r1, ok := all.rs[0].(*FileRepo); assert.True(t, ok) {


### PR DESCRIPTION
- chore: rename GetSpecdOrAll to GetUnion
- doc: add adr002-dont-infer-repo-type-from-uri-scheme.md
- refactor: centralize and unify sorting logic of TMVersions; ensure the default sorting of versions within the same TM name is descending