### PR TITLE
Linux only release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -105,14 +105,14 @@ jobs:
         bash -c "export FILENAME_PREFIX='$env:FILENAME_PREFIX' && ./build/list-dependencies.sh"
 
     - name: Release-Notes
-      if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags') && (runner.os == 'Linux')
       run: |
         echo "Extracting release notes for version ${{github.ref}}"
         export VERSION=${{github.ref_name}}
         bash build/extract-release-notes.sh >> release-notes.md
 
     - name: Release
-      if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags') && (runner.os == 'Linux')
       uses: softprops/action-gh-release@v1
       with:
         body_path: release-notes.md


### PR DESCRIPTION
The [latest release](https://github.com/wot-oss/tmc/actions/runs/19806636773) did not work in the final steps due to linux-specific bash script, which makes sense. We release only for linux but test in mac and windows