### PR TITLE
More binary wildcards for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Binary 
 tmc
+tmc-*
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Build generates the binary for multiple platforms so I am extending the ignore to include those

<img width="305" height="194" alt="Screenshot 2025-12-17 at 12 31 23" src="https://github.com/user-attachments/assets/9a671116-c2e6-4ba3-8f4e-ad31020e5e6a" />
