### PR TITLE
higher-level-attachments for cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `filter.latest` parameter to REST API `/inventory` listing
 - generating `authors.txt`, `manufacturers.txt`, and `mpns.txt` for improving static hosting (e.g. github, github pages)
 - `jwtScopesPrefix` flag to set default prefix for scopes authentication
+- higher-level attachments import/fetch/delete/list in CLI
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - generating `authors.txt`, `manufacturers.txt`, and `mpns.txt` for improving static hosting (e.g. github, github pages)
 - `jwtScopesPrefix` flag to set default prefix for scopes authentication
 - higher-level attachments import/fetch/delete/list in CLI
+- REST API: GET `/authors/{authorName}/.attachments/`, GET `/manufacturers/{authorName}/{manufacturerName}/.attachments/`, GET `/thing-models/.tmName/{tmName}/.attachments`, and GET `/thing-models/{tmID}/.attachments` to list attachments, which belong to the corresponding level (author/manufacturer/tmName/tmID, respectively)
+- REST API: GET `/authors/{authorName}/.attachments/{attachmentFileName}` and GET `/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName}` higher-level attachments fetch
+- REST API: POST `/authors/{authorName}/.attachments/{attachmentFileName}` and POST `/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName}` higher-level attachments import
+- REST API: DELETE `/authors/{authorName}/.attachments/{attachmentFileName}` and DELETE `/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName}` higher-level attachments delete
 - Added `filter.changedSince` parameter to REST API `/inventory` listing and to CLI
 
 ### Changed

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -431,7 +431,7 @@ paths:
       operationId: listThingModelAttachmentsById
       parameters:
         - $ref: '#/components/parameters/TMID'
-        - $ref: '#/components/parameters/RepoConstraint'
+        - $ref: '#/components/parameters/RepoDisambiguator'
       responses:
         '200':
           description: Successful operation
@@ -590,7 +590,7 @@ paths:
           schema:
             type: string
           example: 'siemens/siemens/poc1000'
-        - $ref: '#/components/parameters/RepoConstraint'
+        - $ref: '#/components/parameters/RepoDisambiguator'
       responses:
         '200':
           description: Successful operation
@@ -912,6 +912,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /authors/{authorName}/.attachments:
+    get:
+      tags:
+        - attachments
+      summary: Get the list of attachments to authors
+      description: Returns the list of attachments to authors
+      operationId: listAuthorsAttachments
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentsList'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: No authors found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /manufacturers:
     get:
       tags:
@@ -964,6 +1007,56 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /manufacturers/{authorName}/{manufacturerName}/.attachments:
+    get:
+      tags:
+        - attachments
+      summary: Get the list of attachments to manufacturers
+      description: Returns the list of attachments to manufacturers
+      operationId: listManufacturersAttachments
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: manufacturerName
+          in: path
+          description: Name of manufacturer
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentsList'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: No manufacturers found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal error
           content:

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -413,6 +413,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /thing-models/{tmID}/.attachments:
+    get:
+      tags:
+        - attachments
+      summary: Get the list of attachments to a Thing Model
+      description: Returns the list of attachments to a Thing Model
+      operationId: listThingModelAttachmentsById
+      parameters:
+        - $ref: '#/components/parameters/TMID'
+        - $ref: '#/components/parameters/RepoConstraint'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentsResponse'
+              examples:
+                attachments:
+                  $ref: '#/components/examples/AttachmentsResponseExample'
+        '400':
+          description: Invalid ID supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Thing Model not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /thing-models/{tmID}/.attachments/{attachmentFileName}:
     get:
       tags:
@@ -519,6 +559,52 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Thing Model or inventory name or attachment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /thing-models/.tmName/{tmName}/.attachments:
+    get:
+      tags:
+        - attachments
+      summary: Get the list of attachments to a TM name
+      description: Returns the list of attachments to a TM name from all repositories
+      operationId: listTMNameAttachmentsByName
+      parameters:
+        - name: tmName
+          in: path
+          description: Name of inventory entry
+          required: true
+          schema:
+            type: string
+          example: 'siemens/siemens/poc1000'
+        - $ref: '#/components/parameters/RepoConstraint'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentsResponse'
+              examples:
+                attachments:
+                  $ref: '#/components/examples/AttachmentsResponseExample'
+        '400':
+          description: Invalid TM name supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: TM name not found
           content:
             application/json:
               schema:

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -438,10 +438,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AttachmentsResponse'
-              examples:
-                attachments:
-                  $ref: '#/components/examples/AttachmentsResponseExample'
+                $ref: '#/components/schemas/AttachmentsList'
         '400':
           description: Invalid ID supplied
           content:
@@ -600,10 +597,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AttachmentsResponse'
-              examples:
-                attachments:
-                  $ref: '#/components/examples/AttachmentsResponseExample'
+                $ref: '#/components/schemas/AttachmentsList'
         '400':
           description: Invalid TM name supplied
           content:

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -955,6 +955,157 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /authors/{authorName}/.attachments/{attachmentFileName}:
+    get:
+      tags:
+        - attachments
+      summary: Get the actual content of an attachment to an author
+      description:
+        Returns the content of an attachment to an author
+      operationId: getAuthorAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid ID requested
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Author or attachment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - attachments
+      summary: Upload an attachment to an author
+      description: Upload an attachment to an author
+      operationId: putAuthorAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+        - $ref: '#/components/parameters/ForceImport'
+      requestBody:
+        description: Add a new attachment or overwrite an existing one
+        content:
+          '*/*':
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Successfully added
+        '400':
+          description: Invalid author name supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          description: Conflict, attachment already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - attachments
+      summary: Delete an attachment to an author
+      description: Delete an attachment to an author
+      operationId: deleteAuthorAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '204':
+          description: Successful operation
+        '400':
+          description: Invalid author name supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Author or attachment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /manufacturers:
     get:
       tags:
@@ -1053,6 +1204,178 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: No manufacturers found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName}:
+    get:
+      tags:
+        - attachments
+      summary: Get the actual content of an attachment to a manufacturer
+      description:
+        Returns the content of an attachment to a manufacturer
+      operationId: getManufacturerAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: manufacturerName
+          in: path
+          description: Name of manufacturer
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid ID requested
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Manufacturer or attachment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - attachments
+      summary: Upload an attachment to a manufacturer
+      description: Upload an attachment to a manufacturer
+      operationId: putManufacturerAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: manufacturerName
+          in: path
+          description: Name of manufacturer
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+        - $ref: '#/components/parameters/ForceImport'
+      requestBody:
+        description: Add a new attachment or overwrite an existing one
+        content:
+          '*/*':
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Successfully added
+        '400':
+          description: Invalid author or manufacturer name supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          description: Conflict, attachment already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - attachments
+      summary: Delete an attachment to a manufacturer
+      description: Delete an attachment to a manufacturer
+      operationId: deleteManufacturerAttachmentByName
+      parameters:
+        - name: authorName
+          in: path
+          description: Name of author
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: manufacturerName
+          in: path
+          description: Name of manufacturer
+          required: true
+          schema:
+            type: string
+          example: 'siemens'
+        - name: attachmentFileName
+          in: path
+          description: Name of attachment file
+          required: true
+          schema:
+            type: string
+          example: 'datasheet.pdf'
+        - $ref: '#/components/parameters/RepoDisambiguator'
+      responses:
+        '204':
+          description: Successful operation
+        '400':
+          description: Invalid author or manufacturer name supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Manufacturer or attachment not found
           content:
             application/json:
               schema:

--- a/cmd/attachment/attachment_delete.go
+++ b/cmd/attachment/attachment_delete.go
@@ -11,7 +11,7 @@ import (
 )
 
 var attachmentDeleteCmd = &cobra.Command{
-	Use:   "delete <tm-name-or-id> <attachment-name>",
+	Use:   "delete <identifier> <filename> -t <type>",
 	Short: "Delete an attachment",
 	Long:  `Delete an attachment`,
 	Args:  cobra.ExactArgs(2),
@@ -32,8 +32,14 @@ var attachmentDeleteCmd = &cobra.Command{
 
 func attachmentDelete(command *cobra.Command, args []string) {
 	spec := cmd.RepoSpecFromFlags(command)
+	attTypeStr := command.Flag("type").Value.String()
+	attType, err := parseAttachmentType(attTypeStr)
+	if err != nil {
+		cli.Stderrf("%v", err)
+		os.Exit(1)
+	}
 
-	err := cli.AttachmentDelete(context.Background(), spec, args[0], args[1])
+	err = cli.AttachmentDelete(context.Background(), spec, args[0], attType, args[1])
 	if err != nil {
 		cli.Stderrf("attachment delete failed")
 		os.Exit(1)
@@ -42,5 +48,7 @@ func attachmentDelete(command *cobra.Command, args []string) {
 
 func init() {
 	cmd.AddRepoDisambiguatorFlags(attachmentDeleteCmd)
+	attachmentDeleteCmd.Flags().StringP("type", "t", "", "Type of attachment container: id, name, author, manufacturer")
+	attachmentDeleteCmd.MarkFlagRequired("type")
 	attachmentCmd.AddCommand(attachmentDeleteCmd)
 }

--- a/cmd/attachment/attachment_fetch.go
+++ b/cmd/attachment/attachment_fetch.go
@@ -11,7 +11,7 @@ import (
 )
 
 var attachmentFetchCmd = &cobra.Command{
-	Use:   "fetch <tm-name-or-id> <attachment-name>",
+	Use:   "fetch <identifier> <filename> -t <type>",
 	Short: "Fetch an attachment",
 	Long: `Fetch an attachment to a TM name or a TM ID.
 
@@ -42,7 +42,13 @@ func attachmentFetch(command *cobra.Command, args []string) {
 
 	concat, _ := command.Flags().GetBool("concat")
 	outputPath := command.Flag("output").Value.String()
-	err := cli.AttachmentFetch(context.Background(), spec, args[0], args[1], concat, outputPath)
+	attTypeStr := command.Flag("type").Value.String()
+	attType, err := parseAttachmentType(attTypeStr)
+	if err != nil {
+		cli.Stderrf("%v", err)
+		os.Exit(1)
+	}
+	err = cli.AttachmentFetch(context.Background(), spec, args[0], attType, args[1], concat, outputPath)
 	if err != nil {
 		cli.Stderrf("attachment fetch failed")
 		os.Exit(1)
@@ -54,6 +60,8 @@ func init() {
 	attachmentCmd.AddCommand(attachmentFetchCmd)
 	attachmentFetchCmd.Flags().BoolP("concat", "c", false, "Fetch a concatenation of the attachment to a TM name and homonymous attachments to all versions of the same")
 	attachmentFetchCmd.Flags().StringP("output", "o", "", "Write the fetched attachment to output folder instead of stdout")
+	attachmentFetchCmd.Flags().StringP("type", "t", "", "Type of attachment container: id, name, author, manufacturer")
+	attachmentFetchCmd.MarkFlagRequired("type")
 	_ = attachmentFetchCmd.MarkFlagDirname("output")
 
 }

--- a/cmd/attachment/attachment_import.go
+++ b/cmd/attachment/attachment_import.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,7 +12,7 @@ import (
 )
 
 var attachmentImportCmd = &cobra.Command{
-	Use:   "import <tm-name-or-id> <filename>",
+	Use:   "import <identifier> <filename> -t <type>",
 	Short: "Import an attachment",
 	Long:  `Add or replace an attachment`,
 	Args:  cobra.ExactArgs(2),
@@ -35,10 +36,31 @@ func attachmentImport(command *cobra.Command, args []string) {
 	mediaType := command.Flag("media-type").Value.String()
 	name := command.Flag("name").Value.String()
 	force, _ := command.Flags().GetBool("force")
-	err := cli.AttachmentImport(context.Background(), spec, args[0], args[1], name, mediaType, force)
+	attTypeStr := command.Flag("type").Value.String()
+	attType, err := parseAttachmentType(attTypeStr)
+	if err != nil {
+		cli.Stderrf("%v", err)
+		os.Exit(1)
+	}
+	err = cli.AttachmentImport(context.Background(), spec, args[0], attType, args[1], name, mediaType, force)
 	if err != nil {
 		cli.Stderrf("attachment import failed")
 		os.Exit(1)
+	}
+}
+
+func parseAttachmentType(s string) (cli.AttachmentContainerType, error) {
+	switch s {
+	case "id":
+		return cli.AttachmentTypeTMID, nil
+	case "name":
+		return cli.AttachmentTypeTMName, nil
+	case "author":
+		return cli.AttachmentTypeAuthor, nil
+	case "manufacturer":
+		return cli.AttachmentTypeManufacturer, nil
+	default:
+		return cli.AttachmentTypeInvalid, fmt.Errorf("invalid type: %s, must be one of id, name, author, manufacturer", s)
 	}
 }
 
@@ -48,4 +70,6 @@ func init() {
 	attachmentImportCmd.Flags().StringP("media-type", "m", "", "Media type of the attachment. Guessed automatically, if the flag is not set.")
 	attachmentImportCmd.Flags().StringP("name", "n", "", "Use this name for the attachment instead of the original file name")
 	attachmentImportCmd.Flags().Bool("force", false, `Force import, even if there is conflict with existing attachment.`)
+	attachmentImportCmd.Flags().StringP("type", "t", "", "Type of attachment container: id, name, author, manufacturer")
+	attachmentImportCmd.MarkFlagRequired("type")
 }

--- a/cmd/attachment/attachment_list.go
+++ b/cmd/attachment/attachment_list.go
@@ -8,6 +8,8 @@ import (
 	"github.com/wot-oss/tmc/cmd"
 	"github.com/wot-oss/tmc/cmd/completion"
 	"github.com/wot-oss/tmc/internal/app/cli"
+	"github.com/wot-oss/tmc/internal/commands"
+	"github.com/wot-oss/tmc/internal/model"
 )
 
 var attachmentListCmd = &cobra.Command{
@@ -43,6 +45,10 @@ func attachmentList(command *cobra.Command, args []string) {
 		cli.Stderrf("attachment list failed")
 		os.Exit(1)
 	}
+}
+
+func ListAttachments(ctx context.Context, spec model.RepoSpec, identifier string, ref model.AttachmentContainerRef) ([]model.FoundAttachment, error) {
+	return commands.ListAttachments(ctx, spec, identifier, ref)
 }
 
 func init() {

--- a/cmd/attachment/attachment_list.go
+++ b/cmd/attachment/attachment_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 var attachmentListCmd = &cobra.Command{
-	Use:   "list <tm-name-or-id>",
+	Use:   "list <identifier> -t <type>",
 	Short: "List attachments",
 	Long:  `List attachments to given inventory TM name or id`,
 	Args:  cobra.ExactArgs(1),
@@ -31,8 +31,14 @@ var attachmentListCmd = &cobra.Command{
 func attachmentList(command *cobra.Command, args []string) {
 	spec := cmd.RepoSpecFromFlags(command)
 	format := command.Flag("format").Value.String()
+	attTypeStr := command.Flag("type").Value.String()
+	attType, err := parseAttachmentType(attTypeStr)
+	if err != nil {
+		cli.Stderrf("%v", err)
+		os.Exit(1)
+	}
 
-	err := cli.AttachmentList(context.Background(), spec, args[0], format)
+	err = cli.AttachmentList(context.Background(), spec, args[0], attType, format)
 	if err != nil {
 		cli.Stderrf("attachment list failed")
 		os.Exit(1)
@@ -42,5 +48,7 @@ func attachmentList(command *cobra.Command, args []string) {
 func init() {
 	cmd.AddRepoDisambiguatorFlags(attachmentListCmd)
 	cmd.AddOutputFormatFlag(attachmentListCmd)
+	attachmentListCmd.Flags().StringP("type", "t", "", "Type of attachment container: id, name, author, manufacturer")
+	attachmentListCmd.MarkFlagRequired("type")
 	attachmentCmd.AddCommand(attachmentListCmd)
 }

--- a/internal/app/cli/attachment.go
+++ b/internal/app/cli/attachment.go
@@ -14,8 +14,18 @@ import (
 	"github.com/wot-oss/tmc/internal/utils"
 )
 
-func AttachmentList(ctx context.Context, spec model.RepoSpec, tmNameOrId, format string) error {
-	ref := toAttachmentContainerRef(tmNameOrId)
+type AttachmentContainerType int
+
+const (
+	AttachmentTypeInvalid = iota
+	AttachmentTypeAuthor
+	AttachmentTypeManufacturer
+	AttachmentTypeTMName
+	AttachmentTypeTMID
+)
+
+func AttachmentList(ctx context.Context, spec model.RepoSpec, identifier string, attType AttachmentContainerType, format string) error {
+	ref := toAttachmentContainerRef(identifier, attType)
 	if !IsValidOutputFormat(format) {
 		Stderrf("%v", ErrInvalidOutputFormat)
 		return ErrInvalidOutputFormat
@@ -27,7 +37,7 @@ func AttachmentList(ctx context.Context, spec model.RepoSpec, tmNameOrId, format
 	case model.AttachmentContainerKindTMID:
 		var fvs []model.FoundVersion
 		var errs []*repos.RepoAccessError
-		fvs, err, errs = commands.GetTMMetadata(ctx, spec, tmNameOrId)
+		fvs, err, errs = commands.GetTMMetadata(ctx, spec, identifier)
 		defer printErrs("Errors occurred while getting TM metadata:", errs)
 		for _, m := range fvs {
 			for _, a := range m.Attachments {
@@ -37,10 +47,10 @@ func AttachmentList(ctx context.Context, spec model.RepoSpec, tmNameOrId, format
 				})
 			}
 		}
-	case model.AttachmentContainerKindTMName:
+	case model.AttachmentContainerKindAuthor, model.AttachmentContainerKindManufacturer, model.AttachmentContainerKindTMName:
 		var res model.SearchResult
 		var errs []*repos.RepoAccessError
-		res, err, errs = commands.List(ctx, spec, &model.Filters{Name: tmNameOrId})
+		res, err, errs = commands.List(ctx, spec, &model.Filters{Name: identifier})
 		defer printErrs("Errors occurred while listing:", errs)
 		for _, m := range res.Entries {
 			for _, a := range m.Attachments {
@@ -52,7 +62,7 @@ func AttachmentList(ctx context.Context, spec model.RepoSpec, tmNameOrId, format
 		}
 	}
 	if err != nil {
-		Stderrf("Could not list attachments for %s: %v", tmNameOrId, err)
+		Stderrf("Could not list attachments for %s: %v", identifier, err)
 		return err
 	}
 
@@ -80,7 +90,7 @@ func printAttachments(atts []model.FoundAttachment) {
 
 }
 
-func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, filename, attachmentName, mediaType string, force bool) error {
+func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId string, attType AttachmentContainerType, filename, attachmentName, mediaType string, force bool) error {
 	abs, err := filepath.Abs(filename)
 	if err != nil {
 		Stderrf("Error expanding file name %s: %v", filename, err)
@@ -99,7 +109,7 @@ func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, file
 	if attachmentName == "" {
 		attachmentName = filepath.Base(filename)
 	}
-	err = commands.ImportAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId), model.Attachment{
+	err = commands.ImportAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId, attType), model.Attachment{
 		Name:      attachmentName,
 		MediaType: mediaType,
 	}, raw, force)
@@ -109,16 +119,16 @@ func AttachmentImport(ctx context.Context, spec model.RepoSpec, tmNameOrId, file
 
 	return err
 }
-func AttachmentDelete(ctx context.Context, spec model.RepoSpec, tmNameOrId, attachmentName string) error {
-	err := commands.DeleteAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId), attachmentName)
+func AttachmentDelete(ctx context.Context, spec model.RepoSpec, tmNameOrId string, attType AttachmentContainerType, attachmentName string) error {
+	err := commands.DeleteAttachment(ctx, spec, toAttachmentContainerRef(tmNameOrId, attType), attachmentName)
 	if err != nil {
 		Stderrf("Failed to delete attachment %s to %s: %v", attachmentName, tmNameOrId, err)
 	}
 
 	return err
 }
-func AttachmentFetch(ctx context.Context, spec model.RepoSpec, tmNameOrId, attachmentName string, concat bool, outputPath string) error {
-	content, err := commands.AttachmentFetch(ctx, spec, toAttachmentContainerRef(tmNameOrId), attachmentName, concat)
+func AttachmentFetch(ctx context.Context, spec model.RepoSpec, tmNameOrId string, attType AttachmentContainerType, attachmentName string, concat bool, outputPath string) error {
+	content, err := commands.AttachmentFetch(ctx, spec, toAttachmentContainerRef(tmNameOrId, attType), attachmentName, concat)
 	if err != nil {
 		Stderrf("Failed to fetch attachment %s to %s: %v", attachmentName, tmNameOrId, err)
 		return err
@@ -151,10 +161,22 @@ func AttachmentFetch(ctx context.Context, spec model.RepoSpec, tmNameOrId, attac
 	return nil
 }
 
-func toAttachmentContainerRef(tmNameOrId string) model.AttachmentContainerRef {
-	_, err := model.ParseTMID(tmNameOrId)
-	if err != nil {
-		return model.NewTMNameAttachmentContainerRef(tmNameOrId)
+func toAttachmentContainerRef(identifier string, containerType AttachmentContainerType) model.AttachmentContainerRef {
+	switch containerType {
+	case AttachmentTypeAuthor:
+		return model.NewAuthorAttachmentContainerRef(identifier)
+	case AttachmentTypeManufacturer:
+		return model.NewManufacturerAttachmentContainerRef(identifier)
+	case AttachmentTypeTMName:
+		return model.NewTMNameAttachmentContainerRef(identifier)
+	case AttachmentTypeTMID:
+		_, err := model.ParseTMID(identifier)
+		if err != nil {
+			Stderrf("could not parse TM id, while creating attachment container reference for %s", identifier)
+			return model.AttachmentContainerRef{}
+		}
+		return model.NewTMIDAttachmentContainerRef(identifier)
+	default:
+		panic(fmt.Sprintf("invalid attachment container type: %v", containerType))
 	}
-	return model.NewTMIDAttachmentContainerRef(tmNameOrId)
 }

--- a/internal/app/cli/attachment.go
+++ b/internal/app/cli/attachment.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/wot-oss/tmc/internal/commands"
 	"github.com/wot-oss/tmc/internal/model"
-	"github.com/wot-oss/tmc/internal/repos"
 	"github.com/wot-oss/tmc/internal/utils"
 )
 
@@ -31,36 +30,7 @@ func AttachmentList(ctx context.Context, spec model.RepoSpec, identifier string,
 		return ErrInvalidOutputFormat
 	}
 
-	var atts []model.FoundAttachment
-	var err error
-	switch ref.Kind() {
-	case model.AttachmentContainerKindTMID:
-		var fvs []model.FoundVersion
-		var errs []*repos.RepoAccessError
-		fvs, err, errs = commands.GetTMMetadata(ctx, spec, identifier)
-		defer printErrs("Errors occurred while getting TM metadata:", errs)
-		for _, m := range fvs {
-			for _, a := range m.Attachments {
-				atts = append(atts, model.FoundAttachment{
-					Attachment: a,
-					FoundIn:    m.FoundIn,
-				})
-			}
-		}
-	case model.AttachmentContainerKindAuthor, model.AttachmentContainerKindManufacturer, model.AttachmentContainerKindTMName:
-		var res model.SearchResult
-		var errs []*repos.RepoAccessError
-		res, err, errs = commands.List(ctx, spec, &model.Filters{Name: identifier})
-		defer printErrs("Errors occurred while listing:", errs)
-		for _, m := range res.Entries {
-			for _, a := range m.Attachments {
-				atts = append(atts, model.FoundAttachment{
-					Attachment: a,
-					FoundIn:    m.FoundIn,
-				})
-			}
-		}
-	}
+	atts, err := commands.ListAttachments(ctx, spec, identifier, ref)
 	if err != nil {
 		Stderrf("Could not list attachments for %s: %v", identifier, err)
 		return err

--- a/internal/app/cli/attachment_test.go
+++ b/internal/app/cli/attachment_test.go
@@ -32,7 +32,7 @@ func TestAttachmentList(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName, OutputFormatPlain)
+		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName, AttachmentTypeTMName, OutputFormatPlain)
 		assert.NoError(t, err)
 		stdout := getOutput()
 		assert.Equal(t, "NAME            MEDIATYPE        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
@@ -50,7 +50,7 @@ func TestAttachmentList(t *testing.T) {
 			},
 			FoundIn: model.FoundSource{},
 		}}, nil).Once()
-		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmId, OutputFormatPlain)
+		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmId, AttachmentTypeTMID, OutputFormatPlain)
 		assert.NoError(t, err)
 		stdout := getOutput()
 		assert.Equal(t, "NAME            MEDIATYPE        REPO\nREADME.md       text/markdown    \nUser Guide.pdf  application/pdf  \n", stdout)
@@ -73,7 +73,7 @@ func TestAttachmentList(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName, OutputFormatJSON)
+		err := AttachmentList(ctx, model.NewDirSpec("somewhere"), tmName, AttachmentTypeTMName, OutputFormatJSON)
 		assert.NoError(t, err)
 		stdout := getOutput()
 		var actual any
@@ -96,13 +96,13 @@ func TestAttachmentImport(t *testing.T) {
 	assert.NoError(t, err)
 	t.Run("with original file name", func(t *testing.T) {
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: ""}, attContent, true).Return(nil).Once()
-		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attFile, "", "", true)
+		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attFile, "", "", true)
 		assert.NoError(t, err)
 	})
 
 	t.Run("with overwritten file name", func(t *testing.T) {
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: "differentName.md", MediaType: ""}, attContent, true).Return(nil).Once()
-		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attFile, "differentName.md", "", true)
+		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attFile, "differentName.md", "", true)
 		assert.NoError(t, err)
 	})
 
@@ -119,7 +119,7 @@ func TestAttachmentFetch(t *testing.T) {
 	attName := "README.md"
 	attContent := []byte("attachment content")
 	r.On("FetchAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), attName).Return(attContent, nil).Once()
-	err := AttachmentFetch(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attName, false, "")
+	err := AttachmentFetch(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attName, false, "")
 	assert.NoError(t, err)
 
 	stdout := getOutput()
@@ -133,6 +133,6 @@ func TestAttachmentDelete(t *testing.T) {
 	tmNameOrId := "author/manufacturer/mpn"
 	attName := "README.md"
 	r.On("DeleteAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), attName).Return(nil).Once()
-	err := AttachmentDelete(ctx, model.NewDirSpec("somewhere"), tmNameOrId, attName)
+	err := AttachmentDelete(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attName)
 	assert.NoError(t, err)
 }

--- a/internal/app/cli/attachment_test.go
+++ b/internal/app/cli/attachment_test.go
@@ -21,6 +21,7 @@ func TestAttachmentList(t *testing.T) {
 		restore, getOutput := testutils.ReplaceStdout()
 		defer restore()
 		tmName := "author/manufacturer/mpn"
+		r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{"mpn"}, nil).Once()
 		r.On("List", ctx, &model.Filters{Name: tmName}).Return(
 			model.SearchResult{
 				Entries: []model.FoundEntry{
@@ -41,6 +42,7 @@ func TestAttachmentList(t *testing.T) {
 		restore, getOutput := testutils.ReplaceStdout()
 		defer restore()
 		tmId := "author/manufacturer/mpn/v0.0.0-20240521143452-d662e089b3eb.tm.json"
+		r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{"author/manufacturer/mpn"}, nil).Once()
 		r.On("GetTMMetadata", ctx, tmId).Return([]model.FoundVersion{{
 			IndexVersion: &model.IndexVersion{
 				AttachmentContainer: model.AttachmentContainer{[]model.Attachment{
@@ -59,6 +61,7 @@ func TestAttachmentList(t *testing.T) {
 		restore, getOutput := testutils.ReplaceStdout()
 		defer restore()
 		tmName := "author/manufacturer/mpn"
+		r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{"mpn"}, nil).Once()
 		r.On("List", ctx, &model.Filters{Name: tmName}).Return(
 			model.SearchResult{
 				Entries: []model.FoundEntry{
@@ -95,12 +98,14 @@ func TestAttachmentImport(t *testing.T) {
 	attContent, err := os.ReadFile(attFile)
 	assert.NoError(t, err)
 	t.Run("with original file name", func(t *testing.T) {
+		r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{tmNameOrId}, nil).Once()
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: attName, MediaType: ""}, attContent, true).Return(nil).Once()
 		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attFile, "", "", true)
 		assert.NoError(t, err)
 	})
 
 	t.Run("with overwritten file name", func(t *testing.T) {
+		r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{tmNameOrId}, nil).Once()
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), model.Attachment{Name: "differentName.md", MediaType: ""}, attContent, true).Return(nil).Once()
 		err = AttachmentImport(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attFile, "differentName.md", "", true)
 		assert.NoError(t, err)
@@ -118,6 +123,7 @@ func TestAttachmentFetch(t *testing.T) {
 	tmNameOrId := "author/manufacturer/mpn"
 	attName := "README.md"
 	attContent := []byte("attachment content")
+	r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{tmNameOrId}, nil).Once()
 	r.On("FetchAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), attName).Return(attContent, nil).Once()
 	err := AttachmentFetch(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attName, false, "")
 	assert.NoError(t, err)
@@ -132,6 +138,7 @@ func TestAttachmentDelete(t *testing.T) {
 	ctx := context.Background()
 	tmNameOrId := "author/manufacturer/mpn"
 	attName := "README.md"
+	r.On("Index", ctx).Return([]string{"author"}, []string{"manufacturer"}, []string{tmNameOrId}, nil).Once()
 	r.On("DeleteAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmNameOrId), attName).Return(nil).Once()
 	err := AttachmentDelete(ctx, model.NewDirSpec("somewhere"), tmNameOrId, AttachmentTypeTMName, attName)
 	assert.NoError(t, err)

--- a/internal/app/cli/copy.go
+++ b/internal/app/cli/copy.go
@@ -82,7 +82,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 
 			if !tmExisted {
 				copiedIDs = append(copiedIDs, res.TmID)
-				iErr := target.Index(ctx, res.TmID) // need to index the TM to be able to push attachments to it
+				_, _, _, iErr := target.Index(ctx, res.TmID) // need to index the TM to be able to push attachments to it
 				if iErr != nil {
 					totalRes = append(totalRes, OperationResult{opResultErr, res.TmID, "could not update index"})
 					continue
@@ -121,7 +121,7 @@ func Copy(ctx context.Context, repo model.RepoSpec, toRepo model.RepoSpec, searc
 	}
 
 	if len(copiedIDs) > 0 {
-		indexErr := target.Index(ctx, copiedIDs...)
+		_, _, _, indexErr := target.Index(ctx, copiedIDs...)
 		if indexErr != nil {
 			Stderrf("Cannot update index: %v", indexErr)
 			return indexErr

--- a/internal/app/cli/copy_test.go
+++ b/internal/app/cli/copy_test.go
@@ -129,6 +129,7 @@ func TestCopy(t *testing.T) {
 		source.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
+		source.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Twice()
 		source.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), "CHANGELOG.md").Return(changelogContent, nil).Once()
 		target.On("Import", mock.Anything, model.MustParseTMID(tmID_1), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{Force: true}).
@@ -139,10 +140,10 @@ func TestCopy(t *testing.T) {
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmID_3, Message: "", Err: nil}, nil).Once()
 		target.On("ImportAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), model.Attachment{Name: "README.md"}, readmeContent, true).Return(nil).Once()
 		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), model.Attachment{Name: "CHANGELOG.md"}, changelogContent, true).Return(nil).Once()
-		target.On("Index", mock.Anything, tmID_1, tmID_2, tmID_3).Return(nil)
-		target.On("Index", mock.Anything, tmID_1).Return(nil)
-		target.On("Index", mock.Anything, tmID_2).Return(nil)
-		target.On("Index", mock.Anything, tmID_3).Return(nil)
+		target.On("Index", mock.Anything, tmID_1, tmID_2, tmID_3).Return([]string{}, []string{}, []string{}, nil)
+		target.On("Index", mock.Anything, tmID_1).Return([]string{}, []string{}, []string{}, nil)
+		target.On("Index", mock.Anything, tmID_2).Return([]string{}, []string{}, []string{}, nil)
+		target.On("Index", mock.Anything, tmID_3).Return([]string{}, []string{}, []string{}, nil)
 
 		// when: copying from repo
 		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{Force: true}, OutputFormatPlain)
@@ -173,6 +174,7 @@ func TestCopy(t *testing.T) {
 		source.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
+		source.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Twice()
 		source.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), "CHANGELOG.md").Return(changelogContent, nil).Once()
 		expRes, impErr := repos.ImportResultFromError(&repos.ErrTMIDConflict{Type: repos.IdConflictSameContent, ExistingId: tmID_1})
@@ -214,6 +216,7 @@ func TestCopy(t *testing.T) {
 		source.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 		source.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
+		source.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Twice()
 		source.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(copyListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_3), "CHANGELOG.md").Return(changelogContent, nil).Once()
 		expRes, impErr := repos.ImportResultFromError(&repos.ErrTMIDConflict{Type: repos.IdConflictSameContent, ExistingId: tmID_1})
@@ -313,10 +316,11 @@ func TestCopy(t *testing.T) {
 		var sp *model.Filters
 		source.On("List", mock.Anything, sp).Return(copySingleListRes, nil).Once()
 		source.On("Fetch", mock.Anything, tmid).Return(tmid, tmContent1, nil).Once()
+		source.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), "README.md").Return(nil, model.ErrAttachmentNotFound).Once()
 		target.On("Import", mock.Anything, model.MustParseTMID(tmid), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid, Message: "", Err: nil}, nil).Once()
-		target.On("Index", mock.Anything, tmid).Return(nil).Twice()
+		target.On("Index", mock.Anything, tmid).Return([]string{}, []string{}, []string{}, nil).Twice()
 
 		// when: copying from repo
 		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{}, OutputFormatPlain)
@@ -365,11 +369,12 @@ func TestCopy(t *testing.T) {
 		var sp *model.Filters
 		source.On("List", mock.Anything, sp).Return(copySingleListRes, nil).Once()
 		source.On("Fetch", mock.Anything, tmid).Return(tmid, tmContent1, nil).Once()
+		source.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Once()
 		source.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), "README.md").Return(readmeContent, nil).Once()
 		target.On("Import", mock.Anything, model.MustParseTMID(tmid), utils.NormalizeLineEndings(tmContent1), repos.ImportOptions{}).
 			Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid, Message: "", Err: nil}, nil).Once()
 		target.On("ImportAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmid), model.Attachment{Name: "README.md", MediaType: "text/markdown"}, readmeContent, false).Return(os.ErrPermission).Once()
-		target.On("Index", mock.Anything, tmid).Return(nil).Twice()
+		target.On("Index", mock.Anything, tmid).Return([]string{}, []string{}, []string{}, nil).Twice()
 
 		// when: copying from repo
 		err := Copy(context.Background(), sourceSpec, targetSpec, nil, repos.ImportOptions{}, OutputFormatPlain)

--- a/internal/app/cli/export_test.go
+++ b/internal/app/cli/export_test.go
@@ -138,6 +138,7 @@ func TestExport(t *testing.T) {
 		r.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 		r.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 		r.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Twice()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(exportListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_2), "CHANGELOG.md").Return(changelogContent, nil).Once()
 
@@ -179,6 +180,7 @@ func TestExport(t *testing.T) {
 		r.On("Fetch", mock.Anything, tmID_1).Return(tmID_1, tmContent1, nil).Once()
 		r.On("Fetch", mock.Anything, tmID_2).Return(tmID_2, tmContent2, nil).Once()
 		r.On("Fetch", mock.Anything, tmID_3).Return(tmID_3, tmContent3, nil).Once()
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Twice()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(exportListRes.Entries[0].Name), "README.md").Return(readmeContent, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID_2), "CHANGELOG.md").Return(changelogContent, nil).Once()
 
@@ -341,6 +343,7 @@ func TestExport(t *testing.T) {
 		var sp *model.Filters
 		r.On("List", mock.Anything, sp).Return(exportSingleListRes, nil).Once()
 		r.On("Fetch", mock.Anything, tmID).Return(tmID, tmContent, nil).Once()
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Once()
 
 		// and given: repo returns an error when fetching an Attachment
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmID), "README.md").Return(nil, errors.New("no attachment for you")).Once()

--- a/internal/app/cli/import.go
+++ b/internal/app/cli/import.go
@@ -146,7 +146,7 @@ func (p *ImportExecutor) importDirectory(ctx context.Context, absDirname string,
 					fmt.Printf("%s: unknown MIME type for extension '%s'\n", d.Name(), ext)
 					mimeType = "application/octet-stream"
 				}
-				err = AttachmentImport(ctx, repo.Spec(), uuidToTmNameMap[filepath.Base(filepath.Dir(path))], path, d.Name(), mimeType, true)
+				err = AttachmentImport(ctx, repo.Spec(), uuidToTmNameMap[filepath.Base(filepath.Dir(path))], AttachmentTypeTMName, path, d.Name(), mimeType, true)
 				if err != nil {
 					fmt.Printf("File ignored while attachment import -- no mapping to TM possible %s: %v\n", d.Name(), err)
 					return nil

--- a/internal/app/cli/import.go
+++ b/internal/app/cli/import.go
@@ -71,7 +71,7 @@ func (p *ImportExecutor) Import(ctx context.Context, filename string, spec model
 	}()
 	successfulIds := getSuccessfulIds(res)
 	if len(successfulIds) > 0 {
-		indexErr := repo.Index(ctx, successfulIds...)
+		_, _, _, indexErr := repo.Index(ctx, successfulIds...)
 		if indexErr != nil {
 			Stderrf("Cannot create index: %v", indexErr)
 			return res, indexErr

--- a/internal/app/cli/import_test.go
+++ b/internal/app/cli/import_test.go
@@ -27,7 +27,7 @@ func TestImportExecutor_Import(t *testing.T) {
 		id := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id)
 		r.On("Import", mock.Anything, tmid, mock.Anything, repos.ImportOptions{}).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: id}, nil)
-		r.On("Index", mock.Anything, id).Return(nil)
+		r.On("Index", mock.Anything, id).Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, repos.ImportOptions{}, OutputFormatPlain)
 		assert.NoError(t, err)
@@ -42,7 +42,7 @@ func TestImportExecutor_Import(t *testing.T) {
 		id := "omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json"
 		tmid := model.MustParseTMID(id)
 		r.On("Import", mock.Anything, tmid, mock.Anything, repos.ImportOptions{}).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: id}, nil)
-		r.On("Index", mock.Anything, id).Return(nil)
+		r.On("Index", mock.Anything, id).Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, repos.ImportOptions{}, OutputFormatJSON)
 		assert.NoError(t, err)
@@ -112,7 +112,7 @@ func TestImportExecutor_Import(t *testing.T) {
 		tmid := model.MustParseTMID(id)
 		opts := repos.ImportOptions{OptPath: "a/b/c"}
 		r.On("Import", mock.Anything, tmid, mock.Anything, opts).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: id}, nil)
-		r.On("Index", mock.Anything, id).Return(nil)
+		r.On("Index", mock.Anything, id).Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import/omnilamp-versioned.json", model.NewRepoSpec("repo"), false, opts, OutputFormatPlain)
 		assert.NoError(t, err)
@@ -156,7 +156,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 			}, cErr)
 		r.On("Index", mock.Anything,
 			"omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json",
-			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return(nil)
+			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), false, opts, OutputFormatPlain)
 		assert.Error(t, err)
@@ -199,7 +199,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 			}, cErr)
 		r.On("Index", mock.Anything,
 			"omnicorp-tm-department/omnicorp/omnilamp/v3.2.1-20231110123243-98b3fbd291f4.tm.json",
-			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return(nil)
+			"omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json").Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), false, opts, OutputFormatPlain)
 		assert.NoError(t, err)
@@ -227,7 +227,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 		id4 := "omnicorp-tm-department/omnicorp/omnilamp/opt/v0.0.0-20231110123246-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id4)
 		r.On("Import", mock.Anything, tmid, mock.Anything, opts).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid.String()}, nil)
-		r.On("Index", mock.Anything, id1, id2, id3, id4).Return(nil)
+		r.On("Index", mock.Anything, id1, id2, id3, id4).Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), false, opts, OutputFormatPlain)
 		assert.NoError(t, err)
@@ -253,7 +253,7 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 		id4 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20231110123246-575dfac219e2.tm.json"
 		tmid = model.MustParseTMID(id4)
 		r.On("Import", mock.Anything, tmid, mock.Anything, repos.ImportOptions{OptPath: "/subfolder"}).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid.String()}, nil)
-		r.On("Index", mock.Anything, id1, id2, id3, id4).Return(nil)
+		r.On("Index", mock.Anything, id1, id2, id3, id4).Return([]string{}, []string{}, []string{}, nil)
 
 		res, err := e.Import(context.Background(), "../../../test/data/import", model.NewRepoSpec("repo"), true, repos.ImportOptions{}, OutputFormatPlain)
 		assert.NoError(t, err)
@@ -276,8 +276,8 @@ func TestImportExecutor_Import_Directory(t *testing.T) {
 		r.On("Import", mock.Anything, tmid1, mock.Anything, opts).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid1.String()}, nil)
 		tmid2 := model.MustParseTMID("omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20231110123244-575dfac219e2.tm.json")
 		r.On("Import", mock.Anything, tmid2, mock.Anything, opts).Return(repos.ImportResult{Type: repos.ImportResultOK, TmID: tmid2.String()}, nil)
-		r.On("Index", mock.Anything).Return(nil)
-		r.On("Index", mock.Anything, tmid1.String(), tmid2.String()).Return(nil)
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil)
+		r.On("Index", mock.Anything, tmid1.String(), tmid2.String()).Return([]string{}, []string{}, []string{}, nil)
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmid1.Name), model.Attachment{Name: "test.svg", MediaType: "image/svg+xml"}, mock.Anything, mock.Anything).Return(nil)
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmid2.Name), model.Attachment{Name: "test.svg", MediaType: "image/svg+xml"}, mock.Anything, mock.Anything).Return(nil)
 		r.On("ImportAttachment", ctx, model.NewTMNameAttachmentContainerRef(tmid2.Name), model.Attachment{Name: "test.txt", MediaType: "text/plain; charset=utf-8"}, mock.Anything, mock.Anything).Return(nil)

--- a/internal/app/cli/index.go
+++ b/internal/app/cli/index.go
@@ -14,7 +14,7 @@ func Index(ctx context.Context, spec model.RepoSpec) error {
 		return err
 	}
 
-	err = repo.Index(ctx)
+	_, _, _, err = repo.Index(ctx)
 
 	if err != nil {
 		Stderrf("could not create Index: %v", err)

--- a/internal/app/cli/index_test.go
+++ b/internal/app/cli/index_test.go
@@ -26,14 +26,14 @@ func TestIndex(t *testing.T) {
 	t.Run("error building index", func(t *testing.T) {
 		rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, model.NewDirSpec("somewhere"), r, nil))
 
-		r.On("Index", mock.Anything).Return(errors.New("something failed")).Once()
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, errors.New("something failed")).Once()
 		err := Index(context.Background(), model.NewDirSpec("somewhere"))
 		assert.ErrorContains(t, err, "something failed")
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, model.NewDirSpec("somewhere"), r, nil))
-		r.On("Index", mock.Anything).Return(nil).Once()
+		r.On("Index", mock.Anything).Return([]string{}, []string{}, []string{}, nil).Once()
 		err := Index(context.Background(), model.NewDirSpec("somewhere"))
 		assert.NoError(t, err)
 	})

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -556,6 +556,7 @@ func (h *TmcHandler) GetThingModelAttachmentByName(w http.ResponseWriter, r *htt
 	ref := model.NewTMIDAttachmentContainerRef(tmid)
 	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, false)
 }
+
 func (h *TmcHandler) GetTMNameAttachment(w http.ResponseWriter, r *http.Request, tmName server.TMName, attachmentFileName server.AttachmentFileName, params server.GetTMNameAttachmentParams) {
 	ref := model.NewTMNameAttachmentContainerRef(tmName)
 	concat := false
@@ -563,6 +564,15 @@ func (h *TmcHandler) GetTMNameAttachment(w http.ResponseWriter, r *http.Request,
 		concat = *params.Concat
 	}
 	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, concat)
+}
+
+func (h *TmcHandler) fetchAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, concat bool) {
+	data, err := h.Service.FetchAttachment(r.Context(), repo, ref, attachmentFileName, concat)
+	if err != nil {
+		HandleErrorResponse(w, r, err)
+		return
+	}
+	HandleByteResponse(w, r, http.StatusOK, MimeOctetStream, data)
 }
 
 func (h *TmcHandler) ListTMNameAttachmentsByName(w http.ResponseWriter, r *http.Request, tmName string, params server.ListTMNameAttachmentsByNameParams) {
@@ -583,13 +593,28 @@ func (h *TmcHandler) ListThingModelAttachmentsById(w http.ResponseWriter, r *htt
 	HandleJsonResponse(w, r, http.StatusOK, atts)
 }
 
-func (h *TmcHandler) fetchAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, concat bool) {
-	data, err := h.Service.FetchAttachment(r.Context(), repo, ref, attachmentFileName, concat)
+func (h *TmcHandler) ListAuthorsAttachments(w http.ResponseWriter, r *http.Request, authorName string, params server.ListAuthorsAttachmentsParams) {
+	atts, err := h.Service.ListAuthorsAttachments(r.Context(), convertRepoName(params.Repo), authorName)
 	if err != nil {
 		HandleErrorResponse(w, r, err)
 		return
 	}
-	HandleByteResponse(w, r, http.StatusOK, MimeOctetStream, data)
+	if atts == nil {
+		atts = []model.FoundAttachment{}
+	}
+	HandleJsonResponse(w, r, http.StatusOK, atts)
+}
+
+func (h *TmcHandler) ListManufacturersAttachments(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, params server.ListManufacturersAttachmentsParams) {
+	atts, err := h.Service.ListManufacturersAttachments(r.Context(), convertRepoName(params.Repo), authorName, manufacturerName)
+	if err != nil {
+		HandleErrorResponse(w, r, err)
+		return
+	}
+	if atts == nil {
+		atts = []model.FoundAttachment{}
+	}
+	HandleJsonResponse(w, r, http.StatusOK, atts)
 }
 
 func (h *TmcHandler) deleteAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string) {

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -565,6 +565,24 @@ func (h *TmcHandler) GetTMNameAttachment(w http.ResponseWriter, r *http.Request,
 	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, concat)
 }
 
+func (h *TmcHandler) ListTMNameAttachmentsByName(w http.ResponseWriter, r *http.Request, tmName string, params server.ListTMNameAttachmentsByNameParams) {
+	atts, err := h.Service.ListTMNameAttachmentsByName(r.Context(), convertRepoName(params.Repo), tmName)
+	if err != nil {
+		HandleErrorResponse(w, r, err)
+		return
+	}
+	HandleJsonResponse(w, r, http.StatusOK, atts)
+}
+
+func (h *TmcHandler) ListThingModelAttachmentsById(w http.ResponseWriter, r *http.Request, tmID server.TMID, params server.ListThingModelAttachmentsByIdParams) {
+	atts, err := h.Service.ListTMIDAttachmentsByID(r.Context(), convertRepoName(params.Repo), tmID)
+	if err != nil {
+		HandleErrorResponse(w, r, err)
+		return
+	}
+	HandleJsonResponse(w, r, http.StatusOK, atts)
+}
+
 func (h *TmcHandler) fetchAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, concat bool) {
 	data, err := h.Service.FetchAttachment(r.Context(), repo, ref, attachmentFileName, concat)
 	if err != nil {

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -688,7 +688,6 @@ func (h *TmcHandler) putAttachment(w http.ResponseWriter, r *http.Request, repo 
 		HandleErrorResponse(w, r, NewBadRequestError(nil, "Empty request body"))
 		return
 	}
-
 	err = h.Service.ImportAttachment(r.Context(), repo, ref, attachmentFileName, b, contentType, force)
 	if err != nil {
 		HandleErrorResponse(w, r, err)

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -566,6 +566,16 @@ func (h *TmcHandler) GetTMNameAttachment(w http.ResponseWriter, r *http.Request,
 	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, concat)
 }
 
+func (h *TmcHandler) GetAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params server.GetAuthorAttachmentByNameParams) {
+	ref := model.NewAuthorAttachmentContainerRef(authorName)
+	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, false)
+}
+
+func (h *TmcHandler) GetManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params server.GetManufacturerAttachmentByNameParams) {
+	ref := model.NewManufacturerAttachmentContainerRef(authorName + "/" + manufacturerName)
+	h.fetchAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, false)
+}
+
 func (h *TmcHandler) fetchAttachment(w http.ResponseWriter, r *http.Request, repo string, ref model.AttachmentContainerRef, attachmentFileName string, concat bool) {
 	data, err := h.Service.FetchAttachment(r.Context(), repo, ref, attachmentFileName, concat)
 	if err != nil {
@@ -637,6 +647,16 @@ func (h *TmcHandler) DeleteTMNameAttachment(w http.ResponseWriter, r *http.Reque
 	h.deleteAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName)
 }
 
+func (h *TmcHandler) DeleteAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params server.DeleteAuthorAttachmentByNameParams) {
+	ref := model.NewAuthorAttachmentContainerRef(authorName)
+	h.deleteAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName)
+}
+
+func (h *TmcHandler) DeleteManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params server.DeleteManufacturerAttachmentByNameParams) {
+	ref := model.NewManufacturerAttachmentContainerRef(authorName + "/" + manufacturerName)
+	h.deleteAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName)
+}
+
 func (h *TmcHandler) PutTMIDAttachment(w http.ResponseWriter, r *http.Request, tmID string, attachmentFileName string, params server.PutTMIDAttachmentParams) {
 	ref := model.NewTMIDAttachmentContainerRef(tmID)
 	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
@@ -644,6 +664,16 @@ func (h *TmcHandler) PutTMIDAttachment(w http.ResponseWriter, r *http.Request, t
 
 func (h *TmcHandler) PutTMNameAttachment(w http.ResponseWriter, r *http.Request, tmName server.TMName, attachmentFileName server.AttachmentFileName, params server.PutTMNameAttachmentParams) {
 	ref := model.NewTMNameAttachmentContainerRef(tmName)
+	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
+}
+
+func (h *TmcHandler) PutAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params server.PutAuthorAttachmentByNameParams) {
+	ref := model.NewAuthorAttachmentContainerRef(authorName)
+	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
+}
+
+func (h *TmcHandler) PutManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params server.PutManufacturerAttachmentByNameParams) {
+	ref := model.NewManufacturerAttachmentContainerRef(authorName + "/" + manufacturerName)
 	h.putAttachment(w, r, convertRepoName(params.Repo), ref, attachmentFileName, r.Header.Get(HeaderContentType), convertForceParam(params.Force))
 }
 

--- a/internal/app/http/mocks/HandlerService.go
+++ b/internal/app/http/mocks/HandlerService.go
@@ -559,6 +559,66 @@ func (_m *HandlerService) ListRepos(ctx context.Context) ([]model.RepoDescriptio
 	return r0, r1
 }
 
+// ListTMIDAttachmentsByID provides a mock function with given fields: ctx, repo, tmID
+func (_m *HandlerService) ListTMIDAttachmentsByID(ctx context.Context, repo string, tmID string) ([]model.FoundAttachment, error) {
+	ret := _m.Called(ctx, repo, tmID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListTMIDAttachmentsByID")
+	}
+
+	var r0 []model.FoundAttachment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]model.FoundAttachment, error)); ok {
+		return rf(ctx, repo, tmID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []model.FoundAttachment); ok {
+		r0 = rf(ctx, repo, tmID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.FoundAttachment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, repo, tmID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListTMNameAttachmentsByName provides a mock function with given fields: ctx, repo, tmName
+func (_m *HandlerService) ListTMNameAttachmentsByName(ctx context.Context, repo string, tmName string) ([]model.FoundAttachment, error) {
+	ret := _m.Called(ctx, repo, tmName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListTMNameAttachmentsByName")
+	}
+
+	var r0 []model.FoundAttachment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]model.FoundAttachment, error)); ok {
+		return rf(ctx, repo, tmName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []model.FoundAttachment); ok {
+		r0 = rf(ctx, repo, tmName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.FoundAttachment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, repo, tmName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SearchInventory provides a mock function with given fields: ctx, repo, query, offset, limit
 func (_m *HandlerService) SearchInventory(ctx context.Context, repo string, query string, offset int, limit int) (*model.SearchResult, error) {
 	ret := _m.Called(ctx, repo, query, offset, limit)

--- a/internal/app/http/mocks/HandlerService.go
+++ b/internal/app/http/mocks/HandlerService.go
@@ -439,6 +439,36 @@ func (_m *HandlerService) ListAuthors(ctx context.Context, filters *model.Filter
 	return r0, r1
 }
 
+// ListAuthorsAttachments provides a mock function with given fields: ctx, repo, authorName
+func (_m *HandlerService) ListAuthorsAttachments(ctx context.Context, repo string, authorName string) ([]model.FoundAttachment, error) {
+	ret := _m.Called(ctx, repo, authorName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAuthorsAttachments")
+	}
+
+	var r0 []model.FoundAttachment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]model.FoundAttachment, error)); ok {
+		return rf(ctx, repo, authorName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []model.FoundAttachment); ok {
+		r0 = rf(ctx, repo, authorName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.FoundAttachment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, repo, authorName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListInventory provides a mock function with given fields: ctx, repo, filters, offset, limit
 func (_m *HandlerService) ListInventory(ctx context.Context, repo string, filters *model.Filters, offset int, limit int) (*model.SearchResult, error) {
 	ret := _m.Called(ctx, repo, filters, offset, limit)
@@ -492,6 +522,36 @@ func (_m *HandlerService) ListManufacturers(ctx context.Context, filters *model.
 
 	if rf, ok := ret.Get(1).(func(context.Context, *model.Filters) error); ok {
 		r1 = rf(ctx, filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListManufacturersAttachments provides a mock function with given fields: ctx, repo, authorName, manufacturerName
+func (_m *HandlerService) ListManufacturersAttachments(ctx context.Context, repo string, authorName string, manufacturerName string) ([]model.FoundAttachment, error) {
+	ret := _m.Called(ctx, repo, authorName, manufacturerName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListManufacturersAttachments")
+	}
+
+	var r0 []model.FoundAttachment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]model.FoundAttachment, error)); ok {
+		return rf(ctx, repo, authorName, manufacturerName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []model.FoundAttachment); ok {
+		r0 = rf(ctx, repo, authorName, manufacturerName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.FoundAttachment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, repo, authorName, manufacturerName)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/app/http/mocks/HandlerService.go
+++ b/internal/app/http/mocks/HandlerService.go
@@ -107,42 +107,6 @@ func (_m *HandlerService) DeleteAttachment(ctx context.Context, repo string, ref
 	return r0
 }
 
-// DeleteAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName
-func (_m *HandlerService) DeleteAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string) error {
-	ret := _m.Called(ctx, repo, authorName, attachmentFileName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteAuthorAttachmentByName")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
-		r0 = rf(ctx, repo, authorName, attachmentFileName)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DeleteManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName
-func (_m *HandlerService) DeleteManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string) error {
-	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteManufacturerAttachmentByName")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
-		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // DeleteThingModel provides a mock function with given fields: ctx, repo, tmID
 func (_m *HandlerService) DeleteThingModel(ctx context.Context, repo string, tmID string) error {
 	ret := _m.Called(ctx, repo, tmID)
@@ -221,36 +185,6 @@ func (_m *HandlerService) FetchAttachment(ctx context.Context, repo string, ref 
 	return r0, r1
 }
 
-// FetchAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName
-func (_m *HandlerService) FetchAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string) ([]byte, error) {
-	ret := _m.Called(ctx, repo, authorName, attachmentFileName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FetchAuthorAttachmentByName")
-	}
-
-	var r0 []byte
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]byte, error)); ok {
-		return rf(ctx, repo, authorName, attachmentFileName)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []byte); ok {
-		r0 = rf(ctx, repo, authorName, attachmentFileName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, repo, authorName, attachmentFileName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // FetchLatestThingModel provides a mock function with given fields: ctx, repo, fetchName, restoreId
 func (_m *HandlerService) FetchLatestThingModel(ctx context.Context, repo string, fetchName string, restoreId bool) ([]byte, error) {
 	ret := _m.Called(ctx, repo, fetchName, restoreId)
@@ -274,36 +208,6 @@ func (_m *HandlerService) FetchLatestThingModel(ctx context.Context, repo string
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
 		r1 = rf(ctx, repo, fetchName, restoreId)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// FetchManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName
-func (_m *HandlerService) FetchManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string) ([]byte, error) {
-	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FetchManufacturerAttachmentByName")
-	}
-
-	var r0 []byte
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) ([]byte, error)); ok {
-		return rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) []byte); ok {
-		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
-		r1 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -470,42 +374,6 @@ func (_m *HandlerService) ImportAttachment(ctx context.Context, repo string, ref
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, model.AttachmentContainerRef, string, []byte, string, bool) error); ok {
 		r0 = rf(ctx, repo, ref, attachmentFileName, content, contentType, force)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// ImportAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName, content, contentType, force
-func (_m *HandlerService) ImportAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string, content []byte, contentType string, force bool) error {
-	ret := _m.Called(ctx, repo, authorName, attachmentFileName, content, contentType, force)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ImportAuthorAttachmentByName")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []byte, string, bool) error); ok {
-		r0 = rf(ctx, repo, authorName, attachmentFileName, content, contentType, force)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// ImportManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force
-func (_m *HandlerService) ImportManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string, content []byte, contentType string, force bool) error {
-	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ImportManufacturerAttachmentByName")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, []byte, string, bool) error); ok {
-		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/app/http/mocks/HandlerService.go
+++ b/internal/app/http/mocks/HandlerService.go
@@ -107,6 +107,42 @@ func (_m *HandlerService) DeleteAttachment(ctx context.Context, repo string, ref
 	return r0
 }
 
+// DeleteAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName
+func (_m *HandlerService) DeleteAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string) error {
+	ret := _m.Called(ctx, repo, authorName, attachmentFileName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAuthorAttachmentByName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, repo, authorName, attachmentFileName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName
+func (_m *HandlerService) DeleteManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string) error {
+	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteManufacturerAttachmentByName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteThingModel provides a mock function with given fields: ctx, repo, tmID
 func (_m *HandlerService) DeleteThingModel(ctx context.Context, repo string, tmID string) error {
 	ret := _m.Called(ctx, repo, tmID)
@@ -185,6 +221,36 @@ func (_m *HandlerService) FetchAttachment(ctx context.Context, repo string, ref 
 	return r0, r1
 }
 
+// FetchAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName
+func (_m *HandlerService) FetchAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string) ([]byte, error) {
+	ret := _m.Called(ctx, repo, authorName, attachmentFileName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchAuthorAttachmentByName")
+	}
+
+	var r0 []byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]byte, error)); ok {
+		return rf(ctx, repo, authorName, attachmentFileName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []byte); ok {
+		r0 = rf(ctx, repo, authorName, attachmentFileName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, repo, authorName, attachmentFileName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchLatestThingModel provides a mock function with given fields: ctx, repo, fetchName, restoreId
 func (_m *HandlerService) FetchLatestThingModel(ctx context.Context, repo string, fetchName string, restoreId bool) ([]byte, error) {
 	ret := _m.Called(ctx, repo, fetchName, restoreId)
@@ -208,6 +274,36 @@ func (_m *HandlerService) FetchLatestThingModel(ctx context.Context, repo string
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
 		r1 = rf(ctx, repo, fetchName, restoreId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// FetchManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName
+func (_m *HandlerService) FetchManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string) ([]byte, error) {
+	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchManufacturerAttachmentByName")
+	}
+
+	var r0 []byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) ([]byte, error)); ok {
+		return rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) []byte); ok {
+		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -374,6 +470,42 @@ func (_m *HandlerService) ImportAttachment(ctx context.Context, repo string, ref
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, model.AttachmentContainerRef, string, []byte, string, bool) error); ok {
 		r0 = rf(ctx, repo, ref, attachmentFileName, content, contentType, force)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ImportAuthorAttachmentByName provides a mock function with given fields: ctx, repo, authorName, attachmentFileName, content, contentType, force
+func (_m *HandlerService) ImportAuthorAttachmentByName(ctx context.Context, repo string, authorName string, attachmentFileName string, content []byte, contentType string, force bool) error {
+	ret := _m.Called(ctx, repo, authorName, attachmentFileName, content, contentType, force)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ImportAuthorAttachmentByName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []byte, string, bool) error); ok {
+		r0 = rf(ctx, repo, authorName, attachmentFileName, content, contentType, force)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ImportManufacturerAttachmentByName provides a mock function with given fields: ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force
+func (_m *HandlerService) ImportManufacturerAttachmentByName(ctx context.Context, repo string, authorName string, manufacturerName string, attachmentFileName string, content []byte, contentType string, force bool) error {
+	ret := _m.Called(ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ImportManufacturerAttachmentByName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, []byte, string, bool) error); ok {
+		r0 = rf(ctx, repo, authorName, manufacturerName, attachmentFileName, content, contentType, force)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/app/http/server/models.gen.go
+++ b/internal/app/http/server/models.gen.go
@@ -403,6 +403,12 @@ type GetThingModelByFetchNameParams struct {
 	RestoreId *bool `form:"restoreId,omitempty" json:"restoreId,omitempty"`
 }
 
+// ListTMNameAttachmentsByNameParams defines parameters for ListTMNameAttachmentsByName.
+type ListTMNameAttachmentsByNameParams struct {
+	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
+	Repo *RepoConstraint `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
 // DeleteTMNameAttachmentParams defines parameters for DeleteTMNameAttachment.
 type DeleteTMNameAttachmentParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
@@ -443,6 +449,12 @@ type GetThingModelByIdParams struct {
 
 	// RestoreId restore the TM's original external id, if it had one
 	RestoreId *bool `form:"restoreId,omitempty" json:"restoreId,omitempty"`
+}
+
+// ListThingModelAttachmentsByIdParams defines parameters for ListThingModelAttachmentsById.
+type ListThingModelAttachmentsByIdParams struct {
+	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
+	Repo *RepoConstraint `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
 // DeleteThingModelAttachmentByNameParams defines parameters for DeleteThingModelAttachmentByName.

--- a/internal/app/http/server/models.gen.go
+++ b/internal/app/http/server/models.gen.go
@@ -267,6 +267,12 @@ type GetAuthorsParams struct {
 	FilterProtocol *string `form:"filter.protocol,omitempty" json:"filter.protocol,omitempty"`
 }
 
+// ListAuthorsAttachmentsParams defines parameters for ListAuthorsAttachments.
+type ListAuthorsAttachmentsParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
 // GetInventoryParams defines parameters for GetInventory.
 type GetInventoryParams struct {
 	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
@@ -357,6 +363,12 @@ type GetManufacturersParams struct {
 	FilterProtocol *string `form:"filter.protocol,omitempty" json:"filter.protocol,omitempty"`
 }
 
+// ListManufacturersAttachmentsParams defines parameters for ListManufacturersAttachments.
+type ListManufacturersAttachmentsParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
 // GetMpnsParams defines parameters for GetMpns.
 type GetMpnsParams struct {
 	// FilterAuthor Filters the mpns according to whether they belong to at least one of the given authors with an exact match.
@@ -405,8 +417,8 @@ type GetThingModelByFetchNameParams struct {
 
 // ListTMNameAttachmentsByNameParams defines parameters for ListTMNameAttachmentsByName.
 type ListTMNameAttachmentsByNameParams struct {
-	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
-	Repo *RepoConstraint `form:"repo,omitempty" json:"repo,omitempty"`
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
 // DeleteTMNameAttachmentParams defines parameters for DeleteTMNameAttachment.
@@ -453,8 +465,8 @@ type GetThingModelByIdParams struct {
 
 // ListThingModelAttachmentsByIdParams defines parameters for ListThingModelAttachmentsById.
 type ListThingModelAttachmentsByIdParams struct {
-	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
-	Repo *RepoConstraint `form:"repo,omitempty" json:"repo,omitempty"`
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
 // DeleteThingModelAttachmentByNameParams defines parameters for DeleteThingModelAttachmentByName.

--- a/internal/app/http/server/models.gen.go
+++ b/internal/app/http/server/models.gen.go
@@ -273,6 +273,27 @@ type ListAuthorsAttachmentsParams struct {
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
+// DeleteAuthorAttachmentByNameParams defines parameters for DeleteAuthorAttachmentByName.
+type DeleteAuthorAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
+// GetAuthorAttachmentByNameParams defines parameters for GetAuthorAttachmentByName.
+type GetAuthorAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
+// PutAuthorAttachmentByNameParams defines parameters for PutAuthorAttachmentByName.
+type PutAuthorAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// Force flag to force the import, ignoring any conflicts with existing data
+	Force *ForceImport `form:"force,omitempty" json:"force,omitempty"`
+}
+
 // GetInventoryParams defines parameters for GetInventory.
 type GetInventoryParams struct {
 	// Repo Source repository name. Optionally constrains the results to only those from given named repository. See '/repos'
@@ -367,6 +388,27 @@ type GetManufacturersParams struct {
 type ListManufacturersAttachmentsParams struct {
 	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
 	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
+// DeleteManufacturerAttachmentByNameParams defines parameters for DeleteManufacturerAttachmentByName.
+type DeleteManufacturerAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
+// GetManufacturerAttachmentByNameParams defines parameters for GetManufacturerAttachmentByName.
+type GetManufacturerAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+}
+
+// PutManufacturerAttachmentByNameParams defines parameters for PutManufacturerAttachmentByName.
+type PutManufacturerAttachmentByNameParams struct {
+	// Repo Source/target repository name. The parameter is required when repository is ambiguous. See '/repos'
+	Repo *RepoDisambiguator `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// Force flag to force the import, ignoring any conflicts with existing data
+	Force *ForceImport `form:"force,omitempty" json:"force,omitempty"`
 }
 
 // GetMpnsParams defines parameters for GetMpns.

--- a/internal/app/http/server/server.gen.go
+++ b/internal/app/http/server/server.gen.go
@@ -68,6 +68,9 @@ type ServerInterface interface {
 	// Get the content of a Thing Model by fetch name
 	// (GET /thing-models/.latest/{fetchName})
 	GetThingModelByFetchName(w http.ResponseWriter, r *http.Request, fetchName FetchName, params GetThingModelByFetchNameParams)
+	// Get the list of attachments to a TM name
+	// (GET /thing-models/.tmName/{tmName}/.attachments)
+	ListTMNameAttachmentsByName(w http.ResponseWriter, r *http.Request, tmName string, params ListTMNameAttachmentsByNameParams)
 	// Delete an attachment to a TM name
 	// (DELETE /thing-models/.tmName/{tmName}/.attachments/{attachmentFileName})
 	DeleteTMNameAttachment(w http.ResponseWriter, r *http.Request, tmName TMName, attachmentFileName AttachmentFileName, params DeleteTMNameAttachmentParams)
@@ -83,6 +86,9 @@ type ServerInterface interface {
 	// Get the content of a Thing Model by its ID
 	// (GET /thing-models/{tmID})
 	GetThingModelById(w http.ResponseWriter, r *http.Request, tmID TMID, params GetThingModelByIdParams)
+	// Get the list of attachments to a Thing Model
+	// (GET /thing-models/{tmID}/.attachments)
+	ListThingModelAttachmentsById(w http.ResponseWriter, r *http.Request, tmID TMID, params ListThingModelAttachmentsByIdParams)
 	// Delete an attachment to a Thing Model
 	// (DELETE /thing-models/{tmID}/.attachments/{attachmentFileName})
 	DeleteThingModelAttachmentByName(w http.ResponseWriter, r *http.Request, tmID TMID, attachmentFileName AttachmentFileName, params DeleteThingModelAttachmentByNameParams)
@@ -756,6 +762,45 @@ func (siw *ServerInterfaceWrapper) GetThingModelByFetchName(w http.ResponseWrite
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
+// ListTMNameAttachmentsByName operation middleware
+func (siw *ServerInterfaceWrapper) ListTMNameAttachmentsByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "tmName" -------------
+	var tmName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "tmName", mux.Vars(r)["tmName"], &tmName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tmName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListTMNameAttachmentsByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListTMNameAttachmentsByName(w, r, tmName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
 // DeleteTMNameAttachment operation middleware
 func (siw *ServerInterfaceWrapper) DeleteTMNameAttachment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -1008,6 +1053,45 @@ func (siw *ServerInterfaceWrapper) GetThingModelById(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetThingModelById(w, r, tmID, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// ListThingModelAttachmentsById operation middleware
+func (siw *ServerInterfaceWrapper) ListThingModelAttachmentsById(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "tmID" -------------
+	var tmID TMID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "tmID", mux.Vars(r)["tmID"], &tmID, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tmID", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListThingModelAttachmentsByIdParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListThingModelAttachmentsById(w, r, tmID, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1293,6 +1377,10 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.GetThingModelAttachmentByName).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.DeleteThingModelAttachmentByName).Methods("DELETE")
+
+	r.HandleFunc(options.BaseURL+"/thing-models/.tmName/{tmName:.+}/.attachments", wrapper.ListTMNameAttachmentsByName).Methods("GET")
+
+	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments", wrapper.ListThingModelAttachmentsById).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/.latest/{fetchName:.+}", wrapper.GetThingModelByFetchName).Methods("GET")
 

--- a/internal/app/http/server/server.gen.go
+++ b/internal/app/http/server/server.gen.go
@@ -20,6 +20,9 @@ type ServerInterface interface {
 	// Get the contained authors of the inventory
 	// (GET /authors)
 	GetAuthors(w http.ResponseWriter, r *http.Request, params GetAuthorsParams)
+	// Get the list of attachments to authors
+	// (GET /authors/{authorName}/.attachments)
+	ListAuthorsAttachments(w http.ResponseWriter, r *http.Request, authorName string, params ListAuthorsAttachmentsParams)
 	// Get the overall health of the service
 	// (GET /healthz)
 	GetHealth(w http.ResponseWriter, r *http.Request)
@@ -50,6 +53,9 @@ type ServerInterface interface {
 	// Get the contained manufacturers of the inventory
 	// (GET /manufacturers)
 	GetManufacturers(w http.ResponseWriter, r *http.Request, params GetManufacturersParams)
+	// Get the list of attachments to manufacturers
+	// (GET /manufacturers/{authorName}/{manufacturerName}/.attachments)
+	ListManufacturersAttachments(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, params ListManufacturersAttachmentsParams)
 	// Get the contained mpns (manufacturer part numbers) of the inventory
 	// (GET /mpns)
 	GetMpns(w http.ResponseWriter, r *http.Request, params GetMpnsParams)
@@ -192,6 +198,45 @@ func (siw *ServerInterfaceWrapper) GetAuthors(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAuthors(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// ListAuthorsAttachments operation middleware
+func (siw *ServerInterfaceWrapper) ListAuthorsAttachments(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListAuthorsAttachmentsParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuthorsAttachments(w, r, authorName, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -550,6 +595,54 @@ func (siw *ServerInterfaceWrapper) GetManufacturers(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetManufacturers(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// ListManufacturersAttachments operation middleware
+func (siw *ServerInterfaceWrapper) ListManufacturersAttachments(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "manufacturerName" -------------
+	var manufacturerName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "manufacturerName", mux.Vars(r)["manufacturerName"], &manufacturerName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "manufacturerName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListManufacturersAttachmentsParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListManufacturersAttachments(w, r, authorName, manufacturerName, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1380,6 +1473,8 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 
 	r.HandleFunc(options.BaseURL+"/thing-models/.tmName/{tmName:.+}/.attachments", wrapper.ListTMNameAttachmentsByName).Methods("GET")
 
+	r.HandleFunc(options.BaseURL+"/manufacturers/{authorName}/{manufacturerName}/.attachments", wrapper.ListManufacturersAttachments).Methods("GET")
+
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments", wrapper.ListThingModelAttachmentsById).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/.latest/{fetchName:.+}", wrapper.GetThingModelByFetchName).Methods("GET")
@@ -1387,6 +1482,8 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	r.HandleFunc(options.BaseURL+"/inventory/.tmName/{tmName:.+}", wrapper.GetInventoryByName).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/inventory/.latest/{fetchName:.+}", wrapper.GetInventoryByFetchName).Methods("GET")
+
+	r.HandleFunc(options.BaseURL+"/authors/{authorName}/.attachments", wrapper.ListAuthorsAttachments).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}", wrapper.GetThingModelById).Methods("GET")
 

--- a/internal/app/http/server/server.gen.go
+++ b/internal/app/http/server/server.gen.go
@@ -23,6 +23,15 @@ type ServerInterface interface {
 	// Get the list of attachments to authors
 	// (GET /authors/{authorName}/.attachments)
 	ListAuthorsAttachments(w http.ResponseWriter, r *http.Request, authorName string, params ListAuthorsAttachmentsParams)
+	// Delete an attachment to an author
+	// (DELETE /authors/{authorName}/.attachments/{attachmentFileName})
+	DeleteAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params DeleteAuthorAttachmentByNameParams)
+	// Get the actual content of an attachment to an author
+	// (GET /authors/{authorName}/.attachments/{attachmentFileName})
+	GetAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params GetAuthorAttachmentByNameParams)
+	// Upload an attachment to an author
+	// (PUT /authors/{authorName}/.attachments/{attachmentFileName})
+	PutAuthorAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, attachmentFileName string, params PutAuthorAttachmentByNameParams)
 	// Get the overall health of the service
 	// (GET /healthz)
 	GetHealth(w http.ResponseWriter, r *http.Request)
@@ -56,6 +65,15 @@ type ServerInterface interface {
 	// Get the list of attachments to manufacturers
 	// (GET /manufacturers/{authorName}/{manufacturerName}/.attachments)
 	ListManufacturersAttachments(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, params ListManufacturersAttachmentsParams)
+	// Delete an attachment to a manufacturer
+	// (DELETE /manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName})
+	DeleteManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params DeleteManufacturerAttachmentByNameParams)
+	// Get the actual content of an attachment to a manufacturer
+	// (GET /manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName})
+	GetManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params GetManufacturerAttachmentByNameParams)
+	// Upload an attachment to a manufacturer
+	// (PUT /manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName})
+	PutManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request, authorName string, manufacturerName string, attachmentFileName string, params PutManufacturerAttachmentByNameParams)
 	// Get the contained mpns (manufacturer part numbers) of the inventory
 	// (GET /mpns)
 	GetMpns(w http.ResponseWriter, r *http.Request, params GetMpnsParams)
@@ -237,6 +255,158 @@ func (siw *ServerInterfaceWrapper) ListAuthorsAttachments(w http.ResponseWriter,
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListAuthorsAttachments(w, r, authorName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// DeleteAuthorAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAuthorAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteAuthorAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAuthorAttachmentByName(w, r, authorName, attachmentFileName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetAuthorAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) GetAuthorAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAuthorAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAuthorAttachmentByName(w, r, authorName, attachmentFileName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// PutAuthorAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) PutAuthorAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutAuthorAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "force" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "force", r.URL.Query(), &params.Force)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "force", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutAuthorAttachmentByName(w, r, authorName, attachmentFileName, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -643,6 +813,185 @@ func (siw *ServerInterfaceWrapper) ListManufacturersAttachments(w http.ResponseW
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListManufacturersAttachments(w, r, authorName, manufacturerName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// DeleteManufacturerAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) DeleteManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "manufacturerName" -------------
+	var manufacturerName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "manufacturerName", mux.Vars(r)["manufacturerName"], &manufacturerName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "manufacturerName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteManufacturerAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteManufacturerAttachmentByName(w, r, authorName, manufacturerName, attachmentFileName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetManufacturerAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) GetManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "manufacturerName" -------------
+	var manufacturerName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "manufacturerName", mux.Vars(r)["manufacturerName"], &manufacturerName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "manufacturerName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetManufacturerAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetManufacturerAttachmentByName(w, r, authorName, manufacturerName, attachmentFileName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// PutManufacturerAttachmentByName operation middleware
+func (siw *ServerInterfaceWrapper) PutManufacturerAttachmentByName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "authorName" -------------
+	var authorName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "authorName", mux.Vars(r)["authorName"], &authorName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "authorName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "manufacturerName" -------------
+	var manufacturerName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "manufacturerName", mux.Vars(r)["manufacturerName"], &manufacturerName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "manufacturerName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "attachmentFileName" -------------
+	var attachmentFileName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "attachmentFileName", mux.Vars(r)["attachmentFileName"], &attachmentFileName, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "attachmentFileName", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutManufacturerAttachmentByNameParams
+
+	// ------------- Optional query parameter "repo" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repo", r.URL.Query(), &params.Repo)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repo", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "force" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "force", r.URL.Query(), &params.Force)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "force", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutManufacturerAttachmentByName(w, r, authorName, manufacturerName, attachmentFileName, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1465,6 +1814,12 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 
 	r.HandleFunc(options.BaseURL+"/thing-models/.tmName/{tmName:.+}/.attachments/{attachmentFileName:.+}", wrapper.DeleteTMNameAttachment).Methods("DELETE")
 
+	r.HandleFunc(options.BaseURL+"/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName:.+}", wrapper.PutManufacturerAttachmentByName).Methods("PUT")
+
+	r.HandleFunc(options.BaseURL+"/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName:.+}", wrapper.GetManufacturerAttachmentByName).Methods("GET")
+
+	r.HandleFunc(options.BaseURL+"/manufacturers/{authorName}/{manufacturerName}/.attachments/{attachmentFileName:.+}", wrapper.DeleteManufacturerAttachmentByName).Methods("DELETE")
+
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.PutTMIDAttachment).Methods("PUT")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments/{attachmentFileName:.+}", wrapper.GetThingModelAttachmentByName).Methods("GET")
@@ -1474,6 +1829,12 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 	r.HandleFunc(options.BaseURL+"/thing-models/.tmName/{tmName:.+}/.attachments", wrapper.ListTMNameAttachmentsByName).Methods("GET")
 
 	r.HandleFunc(options.BaseURL+"/manufacturers/{authorName}/{manufacturerName}/.attachments", wrapper.ListManufacturersAttachments).Methods("GET")
+
+	r.HandleFunc(options.BaseURL+"/authors/{authorName}/.attachments/{attachmentFileName:.+}", wrapper.PutAuthorAttachmentByName).Methods("PUT")
+
+	r.HandleFunc(options.BaseURL+"/authors/{authorName}/.attachments/{attachmentFileName:.+}", wrapper.GetAuthorAttachmentByName).Methods("GET")
+
+	r.HandleFunc(options.BaseURL+"/authors/{authorName}/.attachments/{attachmentFileName:.+}", wrapper.DeleteAuthorAttachmentByName).Methods("DELETE")
 
 	r.HandleFunc(options.BaseURL+"/thing-models/{tmID:.+}/.attachments", wrapper.ListThingModelAttachmentsById).Methods("GET")
 

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -40,6 +40,8 @@ type HandlerService interface {
 	ListRepos(ctx context.Context) ([]model.RepoDescription, error)
 	ListTMNameAttachmentsByName(ctx context.Context, repo string, tmName string) ([]model.FoundAttachment, error)
 	ListTMIDAttachmentsByID(ctx context.Context, repo string, tmID string) ([]model.FoundAttachment, error)
+	ListAuthorsAttachments(ctx context.Context, repo string, authorName string) ([]model.FoundAttachment, error)
+	ListManufacturersAttachments(ctx context.Context, repo string, authorName string, manufacturerName string) ([]model.FoundAttachment, error)
 }
 
 type defaultHandlerService struct {
@@ -378,6 +380,22 @@ func (dhs *defaultHandlerService) ListTMIDAttachmentsByID(ctx context.Context, r
 		return nil, err
 	}
 	return commands.ListAttachments(ctx, spec, tmID, model.NewTMIDAttachmentContainerRef(tmID))
+}
+
+func (dhs *defaultHandlerService) ListAuthorsAttachments(ctx context.Context, repo string, authorName string) ([]model.FoundAttachment, error) {
+	spec, err := dhs.inferTargetRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return commands.ListAttachments(ctx, spec, authorName, model.NewAuthorAttachmentContainerRef(authorName))
+}
+
+func (dhs *defaultHandlerService) ListManufacturersAttachments(ctx context.Context, repo string, authorName string, manufacturerName string) ([]model.FoundAttachment, error) {
+	spec, err := dhs.inferTargetRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return commands.ListAttachments(ctx, spec, authorName+"/"+manufacturerName, model.NewManufacturerAttachmentContainerRef(authorName+"/"+manufacturerName))
 }
 
 func (dhs *defaultHandlerService) CheckHealth(ctx context.Context) error {

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -38,6 +38,8 @@ type HandlerService interface {
 	ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string, force bool) error
 	DeleteAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string) error
 	ListRepos(ctx context.Context) ([]model.RepoDescription, error)
+	ListTMNameAttachmentsByName(ctx context.Context, repo string, tmName string) ([]model.FoundAttachment, error)
+	ListTMIDAttachmentsByID(ctx context.Context, repo string, tmID string) ([]model.FoundAttachment, error)
 }
 
 type defaultHandlerService struct {
@@ -360,6 +362,22 @@ func (dhs *defaultHandlerService) ImportAttachment(ctx context.Context, repo str
 		MediaType: contentType,
 	}, content, force)
 	return err
+}
+
+func (dhs *defaultHandlerService) ListTMNameAttachmentsByName(ctx context.Context, repo string, tmName string) ([]model.FoundAttachment, error) {
+	spec, err := dhs.inferTargetRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return commands.ListAttachments(ctx, spec, tmName, model.NewTMNameAttachmentContainerRef(tmName))
+}
+
+func (dhs *defaultHandlerService) ListTMIDAttachmentsByID(ctx context.Context, repo string, tmID string) ([]model.FoundAttachment, error) {
+	spec, err := dhs.inferTargetRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return commands.ListAttachments(ctx, spec, tmID, model.NewTMIDAttachmentContainerRef(tmID))
 }
 
 func (dhs *defaultHandlerService) CheckHealth(ctx context.Context) error {

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -239,7 +239,7 @@ func (dhs *defaultHandlerService) ImportThingModel(ctx context.Context, repoName
 		return res, err
 	}
 	if res.IsSuccessful() {
-		err = repo.Index(ctx, res.TmID)
+		_, _, _, err = repo.Index(ctx, res.TmID)
 		if err != nil {
 			return repos.ImportResultFromError(err)
 		}

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -346,6 +346,7 @@ func (dhs *defaultHandlerService) FetchAttachment(ctx context.Context, repo stri
 	content, err := commands.AttachmentFetch(ctx, spec, ref, attachmentFileName, concat)
 	return content, err
 }
+
 func (dhs *defaultHandlerService) DeleteAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string) error {
 	spec, err := dhs.inferTargetRepo(ctx, repo)
 	if err != nil {
@@ -354,6 +355,7 @@ func (dhs *defaultHandlerService) DeleteAttachment(ctx context.Context, repo str
 	err = commands.DeleteAttachment(ctx, spec, ref, attachmentFileName)
 	return err
 }
+
 func (dhs *defaultHandlerService) ImportAttachment(ctx context.Context, repo string, ref model.AttachmentContainerRef, attachmentFileName string, content []byte, contentType string, force bool) error {
 	spec, err := dhs.inferTargetRepo(ctx, repo)
 	if err != nil {

--- a/internal/app/http/service_test.go
+++ b/internal/app/http/service_test.go
@@ -600,7 +600,7 @@ func TestService_ImportThingModel(t *testing.T) {
 		}
 
 		r.On("Import", mock.Anything, mock.Anything, mock.Anything, repos.ImportOptions{}).Return(expRes, nil).Once()
-		r.On("Index", mock.Anything, "new-id").Return(nil)
+		r.On("Index", mock.Anything, "new-id").Return([]string{}, []string{}, []string{}, nil)
 		// when: importing ThingModel
 		res, err := underTest.ImportThingModel(context.Background(), "", tmContent, repos.ImportOptions{})
 		// then: it returns expected warning result
@@ -632,6 +632,7 @@ func TestService_FetchAttachment(t *testing.T) {
 	attName := "README.md"
 	// given: repo returns an attachment
 	r := mocks.NewRepo(t)
+	r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 	r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(attContent, nil).Once()
 	rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, repo, r, nil))
 	// when: fetching an attachment
@@ -654,6 +655,7 @@ func TestService_FetchAttachment_WithConcat(t *testing.T) {
 	t.Run("with TM name attachment", func(t *testing.T) {
 		// given: repo with a README.md attachment on TM name and two TM IDs
 		r := mocks.NewRepo(t)
+		r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(attContent1, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmidV1), attName).Return(attContent2, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmidV2), attName).Return(attContent3, nil).Once()
@@ -709,6 +711,7 @@ func TestService_FetchAttachment_WithConcat(t *testing.T) {
 	t.Run("without TM name attachment", func(t *testing.T) {
 		// given: repo with a README.md attachment on two TM IDs, but not on TM name
 		r := mocks.NewRepo(t)
+		r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(nil, model.ErrAttachmentNotFound).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmidV1), attName).Return(attContent2, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmidV2), attName).Return(attContent3, nil).Once()
@@ -762,6 +765,7 @@ func TestService_FetchAttachment_WithConcat(t *testing.T) {
 	t.Run("with one TMID attachment missing", func(t *testing.T) {
 		// given: repo with a README.md attachment on TM name and one of two TM IDs
 		r := mocks.NewRepo(t)
+		r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(attContent1, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMIDAttachmentContainerRef(tmidV1), attName).Return(attContent2, nil).Once()
 		r.On("List", mock.Anything, &model.Filters{Name: inventoryName}).Return(model.SearchResult{
@@ -807,6 +811,7 @@ func TestService_FetchAttachment_WithConcat(t *testing.T) {
 	t.Run("with both TMID attachments missing", func(t *testing.T) {
 		// given: repo with a README.md attachment on TM name but none of two TM IDs
 		r := mocks.NewRepo(t)
+		r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(attContent1, nil).Once()
 		r.On("List", mock.Anything, &model.Filters{Name: inventoryName}).Return(model.SearchResult{
 			Entries: []model.FoundEntry{
@@ -850,6 +855,7 @@ func TestService_FetchAttachment_WithConcat(t *testing.T) {
 	t.Run("with all attachments missing", func(t *testing.T) {
 		// given: repo with no README.md attachment on TM name nor any of the TM IDs
 		r := mocks.NewRepo(t)
+		r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 		r.On("FetchAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(nil, model.ErrAttachmentNotFound).Once()
 		r.On("List", mock.Anything, &model.Filters{Name: inventoryName}).Return(model.SearchResult{
 			Entries: []model.FoundEntry{
@@ -898,6 +904,7 @@ func TestService_ImportAttachment(t *testing.T) {
 	attName := "README.md"
 	// given: a repo
 	r := mocks.NewRepo(t)
+	r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 	r.On("ImportAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), model.Attachment{
 		Name:      attName,
 		MediaType: "text/markdown",
@@ -916,6 +923,7 @@ func TestService_DeleteAttachment(t *testing.T) {
 	attName := "README.md"
 	// given: repo returns an attachment
 	r := mocks.NewRepo(t)
+	r.On("Index", mock.Anything).Return([]string{"a"}, []string{"b"}, []string{inventoryName}, nil).Once()
 	r.On("DeleteAttachment", mock.Anything, model.NewTMNameAttachmentContainerRef(inventoryName), attName).Return(nil).Once()
 	rMocks.MockReposGet(t, rMocks.CreateMockGetFunction(t, repo, r, nil))
 	// when: deleting an attachment

--- a/internal/commands/attachment.go
+++ b/internal/commands/attachment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/wot-oss/tmc/internal/model"
@@ -12,6 +13,12 @@ import (
 
 func ImportAttachment(ctx context.Context, spec model.RepoSpec, ref model.AttachmentContainerRef, att model.Attachment, content []byte, force bool) error {
 	repo, err := repos.Get(spec)
+
+	if err != nil {
+		return err
+	}
+
+	err = CheckAttachmentRefByType(ctx, repo, ref)
 	if err != nil {
 		return err
 	}
@@ -24,6 +31,12 @@ func ImportAttachment(ctx context.Context, spec model.RepoSpec, ref model.Attach
 
 func DeleteAttachment(ctx context.Context, spec model.RepoSpec, ref model.AttachmentContainerRef, attachmentName string) error {
 	repo, err := repos.Get(spec)
+
+	err = CheckAttachmentRefByType(ctx, repo, ref)
+	if err != nil {
+		return err
+	}
+
 	if err != nil {
 		return err
 	}
@@ -33,6 +46,11 @@ func DeleteAttachment(ctx context.Context, spec model.RepoSpec, ref model.Attach
 }
 func AttachmentFetch(ctx context.Context, spec model.RepoSpec, ref model.AttachmentContainerRef, attachmentName string, concat bool) ([]byte, error) {
 	repo, err := repos.Get(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	err = CheckAttachmentRefByType(ctx, repo, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -74,4 +92,31 @@ func AttachmentFetch(ctx context.Context, spec model.RepoSpec, ref model.Attachm
 		return nil, model.ErrAttachmentNotFound
 	}
 	return att, nil
+}
+
+func CheckAttachmentRefByType(ctx context.Context, repo repos.Repo, ref model.AttachmentContainerRef) error {
+	authors, manufacturers, _, err := repo.Index(ctx)
+	if err != nil {
+		return err
+	}
+	switch ref.Kind() {
+	case model.AttachmentContainerKindAuthor:
+		if !slices.Contains(authors, ref.Author) {
+			return errors.New("author not found in repo")
+		}
+	case model.AttachmentContainerKindManufacturer:
+		if !slices.Contains(authors, strings.Split(ref.Manufacturer, "/")[0]) || !slices.Contains(manufacturers, strings.Split(ref.Manufacturer, "/")[1]) {
+			return errors.New("manufacturer not found in repo")
+		}
+	case model.AttachmentContainerKindTMName:
+		// no need
+	case model.AttachmentContainerKindTMID:
+		// no need to check existence of TM ID as it will be checked when trying to import the attachment
+	default:
+		return errors.New("invalid attachment container type")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/commands/attachment_list.go
+++ b/internal/commands/attachment_list.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/wot-oss/tmc/internal/model"
+)
+
+func ListAttachments(ctx context.Context, spec model.RepoSpec, identifier string, ref model.AttachmentContainerRef) ([]model.FoundAttachment, error) {
+	var atts []model.FoundAttachment
+	var err error
+
+	switch ref.Kind() {
+	case model.AttachmentContainerKindTMID:
+		var fvs []model.FoundVersion
+		fvs, err, _ = GetTMMetadata(ctx, spec, identifier)
+		for _, m := range fvs {
+			for _, a := range m.Attachments {
+				atts = append(atts, model.FoundAttachment{
+					Attachment: a,
+					FoundIn:    m.FoundIn,
+				})
+			}
+		}
+	case model.AttachmentContainerKindAuthor, model.AttachmentContainerKindManufacturer, model.AttachmentContainerKindTMName:
+		var res model.SearchResult
+		res, err, _ = List(ctx, spec, &model.Filters{Name: identifier})
+		for _, m := range res.Entries {
+			for _, a := range m.Attachments {
+				atts = append(atts, model.FoundAttachment{
+					Attachment: a,
+					FoundIn:    m.FoundIn,
+				})
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return atts, nil
+}

--- a/internal/commands/attachment_list.go
+++ b/internal/commands/attachment_list.go
@@ -4,11 +4,20 @@ import (
 	"context"
 
 	"github.com/wot-oss/tmc/internal/model"
+	"github.com/wot-oss/tmc/internal/repos"
 )
 
 func ListAttachments(ctx context.Context, spec model.RepoSpec, identifier string, ref model.AttachmentContainerRef) ([]model.FoundAttachment, error) {
 	var atts []model.FoundAttachment
 	var err error
+	repo, err := repos.Get(spec)
+	if err != nil {
+		return nil, err
+	}
+	err = CheckAttachmentRefByType(ctx, repo, ref)
+	if err != nil {
+		return nil, err
+	}
 
 	switch ref.Kind() {
 	case model.AttachmentContainerKindTMID:

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	ErrTMNotFound         *ErrNotFound
-	ErrTMNameNotFound     *ErrNotFound
-	ErrAttachmentNotFound *ErrNotFound
+	ErrAuthorNotFound       *ErrNotFound
+	ErrManufacturerNotFound *ErrNotFound
+	ErrTMNotFound           *ErrNotFound
+	ErrTMNameNotFound       *ErrNotFound
+	ErrAttachmentNotFound   *ErrNotFound
 )
 
 type ErrNotFound struct {
@@ -28,6 +30,8 @@ func NewErrNotFound(subject string) *ErrNotFound {
 }
 
 func init() {
+	ErrAuthorNotFound = NewErrNotFound("author")
+	ErrManufacturerNotFound = NewErrNotFound("manufacturer")
 	ErrTMNotFound = NewErrNotFound("TM")
 	ErrTMNameNotFound = NewErrNotFound("TM name")
 	ErrAttachmentNotFound = NewErrNotFound("attachment")

--- a/internal/model/search.go
+++ b/internal/model/search.go
@@ -150,7 +150,6 @@ func (sr *SearchResult) Filter(filters *Filters) error {
 		if !matchesProtocolFilter(filters.Protocol, entry) {
 			return true
 		}
-
 		return false
 	}
 	sr.Entries = slices.DeleteFunc(sr.Entries, func(entry FoundEntry) bool {

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -30,9 +30,9 @@ func (idx *Index) reindexData() {
 			}
 		}
 		if len(parts) >= 2 {
-			manufacturerKey := parts[0] + "/" + parts[1]
-			if _, exists := idx.manufacturerAttachments[manufacturerKey]; !exists {
-				idx.manufacturerAttachments[manufacturerKey] = v
+			manufacturerName := parts[0] + "/" + parts[1]
+			if _, exists := idx.manufacturerAttachments[manufacturerName]; !exists {
+				idx.manufacturerAttachments[manufacturerName] = v
 			}
 		}
 	}
@@ -60,8 +60,8 @@ func (ac *AttachmentContainer) FindAttachment(name string) (att Attachment, foun
 
 type IndexEntry struct {
 	Name         string             `json:"name"`
-	Manufacturer SchemaManufacturer `json:"schema:manufacturer" validate:"required"`
-	Mpn          string             `json:"schema:mpn" validate:"required"`
+	Manufacturer SchemaManufacturer `json:"schema:manufacturer"`
+	Mpn          string             `json:"schema:mpn"`
 	Author       SchemaAuthor       `json:"schema:author" validate:"required"`
 	Versions     []*IndexVersion    `json:"versions"`
 	AttachmentContainer
@@ -92,10 +92,10 @@ const (
 )
 
 func NewAuthorAttachmentContainerRef(author string) AttachmentContainerRef {
-	return AttachmentContainerRef{Author: author}
+	return AttachmentContainerRef{TMName: author, Author: author}
 }
 func NewManufacturerAttachmentContainerRef(manufacturer string) AttachmentContainerRef {
-	return AttachmentContainerRef{Manufacturer: manufacturer}
+	return AttachmentContainerRef{TMName: manufacturer, Manufacturer: manufacturer}
 }
 func NewTMIDAttachmentContainerRef(tmid string) AttachmentContainerRef {
 	return AttachmentContainerRef{TMID: tmid}
@@ -184,14 +184,14 @@ func (idx *Index) FindByName(name string) *IndexEntry {
 	return idx.dataByName[name]
 }
 
-func (idx *Index) FindByAuthor(author string) *IndexEntry {
+func (idx *Index) findByAuthor(author string) *IndexEntry {
 	if idx.authorAttachments == nil {
 		idx.reindexData()
 	}
 	return idx.authorAttachments[author]
 }
 
-func (idx *Index) FindByManufacturer(manufacturer string) *IndexEntry {
+func (idx *Index) findByManufacturer(manufacturer string) *IndexEntry {
 	if idx.manufacturerAttachments == nil {
 		idx.reindexData()
 	}
@@ -235,6 +235,32 @@ func (idx *Index) Insert(ctm *ThingModel) error {
 		}
 		idx.Data = append(idx.Data, idxEntry)
 		idx.dataByName[idxEntry.Name] = idxEntry
+	}
+	parts := strings.Split(tmid.Name, "/")
+	if len(parts) >= 1 {
+		authorName := parts[0]
+		idxEntry := idx.findByAuthor(authorName)
+		if idxEntry == nil {
+			idxEntry = &IndexEntry{
+				Name:   parts[0],
+				Author: SchemaAuthor{Name: parts[0]},
+			}
+			idx.Data = append(idx.Data, idxEntry)
+			idx.authorAttachments[idxEntry.Name] = idxEntry
+		}
+	}
+	if len(parts) >= 2 {
+		manufacturerName := parts[0] + "/" + parts[1]
+		idxEntry := idx.findByManufacturer(manufacturerName)
+		if idxEntry == nil {
+			idxEntry = &IndexEntry{
+				Name:         parts[0] + "/" + parts[1],
+				Author:       SchemaAuthor{Name: parts[0]},
+				Manufacturer: SchemaManufacturer{Name: parts[1]},
+			}
+			idx.Data = append(idx.Data, idxEntry)
+			idx.manufacturerAttachments[idxEntry.Name] = idxEntry
+		}
 	}
 	// TODO: check if id already exists?
 	// Append version information to entry
@@ -309,7 +335,15 @@ func (idx *Index) Delete(id string) (updated bool, deletedName string, err error
 			idx.Data = slices.DeleteFunc(idx.Data, func(entry *IndexEntry) bool {
 				return entry.Name == name
 			})
-			delete(idx.dataByName, name)
+			if _, exists := idx.dataByName[name]; exists {
+				delete(idx.dataByName, name)
+			}
+			if _, exists := idx.authorAttachments[name]; exists {
+				delete(idx.authorAttachments, name)
+			}
+			if _, exists := idx.manufacturerAttachments[name]; exists {
+				delete(idx.manufacturerAttachments, name)
+			}
 			return updated, name, nil
 		}
 	}
@@ -323,9 +357,9 @@ func (idx *Index) FindAttachmentContainer(ref AttachmentContainerRef) (*Attachme
 	case AttachmentContainerKindInvalid:
 		return nil, nil, ErrInvalidIdOrName
 	case AttachmentContainerKindAuthor:
-		indexEntry = idx.FindByAuthor(ref.Author)
+		indexEntry = idx.findByAuthor(ref.Author)
 	case AttachmentContainerKindManufacturer:
-		indexEntry = idx.FindByManufacturer(ref.Manufacturer)
+		indexEntry = idx.findByManufacturer(ref.Manufacturer)
 	case AttachmentContainerKindTMID:
 		id, err := ParseTMID(ref.TMID)
 		if err != nil {
@@ -335,7 +369,6 @@ func (idx *Index) FindAttachmentContainer(ref AttachmentContainerRef) (*Attachme
 	case AttachmentContainerKindTMName:
 		fn, err := ParseFetchName(ref.TMName)
 		if err != nil || fn.Semver != "" {
-			fmt.Println("Invalid TM name:", ref.TMName)
 			return nil, nil, ErrInvalidIdOrName
 		}
 		indexEntry = idx.FindByName(ref.TMName)

--- a/internal/model/toc.go
+++ b/internal/model/toc.go
@@ -9,15 +9,32 @@ import (
 )
 
 type Index struct {
-	Meta       IndexMeta     `json:"meta"`
-	Data       []*IndexEntry `json:"data"`
-	dataByName map[string]*IndexEntry
+	Meta                    IndexMeta     `json:"meta"`
+	Data                    []*IndexEntry `json:"data"`
+	dataByName              map[string]*IndexEntry
+	authorAttachments       map[string]*IndexEntry
+	manufacturerAttachments map[string]*IndexEntry
 }
 
 func (idx *Index) reindexData() {
 	idx.dataByName = make(map[string]*IndexEntry)
+	idx.authorAttachments = make(map[string]*IndexEntry)
+	idx.manufacturerAttachments = make(map[string]*IndexEntry)
 	for _, v := range idx.Data {
 		idx.dataByName[v.Name] = v
+		parts := strings.Split(v.Name, "/")
+		if len(parts) >= 1 {
+			authorName := parts[0]
+			if _, exists := idx.authorAttachments[authorName]; !exists {
+				idx.authorAttachments[authorName] = v
+			}
+		}
+		if len(parts) >= 2 {
+			manufacturerKey := parts[0] + "/" + parts[1]
+			if _, exists := idx.manufacturerAttachments[manufacturerKey]; !exists {
+				idx.manufacturerAttachments[manufacturerKey] = v
+			}
+		}
 	}
 }
 
@@ -58,18 +75,28 @@ type Attachment struct {
 // AttachmentContainerRef contains a reference to an entity which can have file attachments
 // Either TMName field must be not empty, or TMID. Never both and never none.
 type AttachmentContainerRef struct {
-	TMName string
-	TMID   string
+	Author       string
+	Manufacturer string
+	TMName       string
+	TMID         string
 }
 
 type AttachmentContainerKind byte
 
 const (
 	AttachmentContainerKindInvalid AttachmentContainerKind = iota
+	AttachmentContainerKindAuthor
+	AttachmentContainerKindManufacturer
 	AttachmentContainerKindTMName
 	AttachmentContainerKindTMID
 )
 
+func NewAuthorAttachmentContainerRef(author string) AttachmentContainerRef {
+	return AttachmentContainerRef{Author: author}
+}
+func NewManufacturerAttachmentContainerRef(manufacturer string) AttachmentContainerRef {
+	return AttachmentContainerRef{Manufacturer: manufacturer}
+}
 func NewTMIDAttachmentContainerRef(tmid string) AttachmentContainerRef {
 	return AttachmentContainerRef{TMID: tmid}
 }
@@ -80,6 +107,10 @@ func (r AttachmentContainerRef) String() string {
 	switch r.Kind() {
 	case AttachmentContainerKindInvalid:
 		return fmt.Sprintf("invalid AttachmentContainerRef (TMID=%s, TMName=%s)", r.TMID, r.TMName)
+	case AttachmentContainerKindAuthor:
+		return fmt.Sprintf("Author=%s", r.Author)
+	case AttachmentContainerKindManufacturer:
+		return fmt.Sprintf("Manufacturer=%s", r.Manufacturer)
 	case AttachmentContainerKindTMID:
 		return fmt.Sprintf("TMID=%s", r.TMID)
 	case AttachmentContainerKindTMName:
@@ -90,8 +121,14 @@ func (r AttachmentContainerRef) String() string {
 }
 
 func (r AttachmentContainerRef) Kind() AttachmentContainerKind {
-	if (r.TMID != "" && r.TMName != "") || (r.TMID == "" && r.TMName == "") {
+	if (r.Author != "" && r.Manufacturer != "" && r.TMID != "" && r.TMName != "") || (r.Author == "" && r.Manufacturer == "" && r.TMID == "" && r.TMName == "") {
 		return AttachmentContainerKindInvalid
+	}
+	if r.Author != "" {
+		return AttachmentContainerKindAuthor
+	}
+	if r.Manufacturer != "" {
+		return AttachmentContainerKindManufacturer
 	}
 	if r.TMName != "" {
 		return AttachmentContainerKindTMName
@@ -145,6 +182,20 @@ func (idx *Index) FindByName(name string) *IndexEntry {
 		idx.reindexData()
 	}
 	return idx.dataByName[name]
+}
+
+func (idx *Index) FindByAuthor(author string) *IndexEntry {
+	if idx.authorAttachments == nil {
+		idx.reindexData()
+	}
+	return idx.authorAttachments[author]
+}
+
+func (idx *Index) FindByManufacturer(manufacturer string) *IndexEntry {
+	if idx.manufacturerAttachments == nil {
+		idx.reindexData()
+	}
+	return idx.manufacturerAttachments[manufacturer]
 }
 
 // FindByTMID searches by TM name and returns a pointer to the IndexVersion if found.
@@ -267,27 +318,35 @@ func (idx *Index) Delete(id string) (updated bool, deletedName string, err error
 
 func (idx *Index) FindAttachmentContainer(ref AttachmentContainerRef) (*AttachmentContainer, *IndexEntry, error) {
 	k := ref.Kind()
-	var tmName string
+	var indexEntry *IndexEntry
 	switch k {
 	case AttachmentContainerKindInvalid:
 		return nil, nil, ErrInvalidIdOrName
+	case AttachmentContainerKindAuthor:
+		indexEntry = idx.FindByAuthor(ref.Author)
+	case AttachmentContainerKindManufacturer:
+		indexEntry = idx.FindByManufacturer(ref.Manufacturer)
 	case AttachmentContainerKindTMID:
 		id, err := ParseTMID(ref.TMID)
 		if err != nil {
 			return nil, nil, err
 		}
-		tmName = id.Name
+		indexEntry = idx.FindByName(id.Name)
 	case AttachmentContainerKindTMName:
 		fn, err := ParseFetchName(ref.TMName)
 		if err != nil || fn.Semver != "" {
+			fmt.Println("Invalid TM name:", ref.TMName)
 			return nil, nil, ErrInvalidIdOrName
 		}
-		tmName = ref.TMName
+		indexEntry = idx.FindByName(ref.TMName)
 	}
 
-	indexEntry := idx.FindByName(tmName)
 	if indexEntry == nil {
-		if ref.Kind() == AttachmentContainerKindTMID {
+		if ref.Kind() == AttachmentContainerKindAuthor {
+			return nil, nil, ErrAuthorNotFound
+		} else if ref.Kind() == AttachmentContainerKindManufacturer {
+			return nil, nil, ErrManufacturerNotFound
+		} else if ref.Kind() == AttachmentContainerKindTMID {
 			return nil, nil, ErrTMNotFound
 		} else {
 			return nil, nil, ErrTMNameNotFound
@@ -315,6 +374,10 @@ func RelAttachmentsDir(ref AttachmentContainerRef) (string, error) {
 	switch ref.Kind() {
 	case AttachmentContainerKindInvalid:
 		return "", fmt.Errorf("invalid attachment container reference: %w: %v", ErrInvalidIdOrName, ref)
+	case AttachmentContainerKindAuthor:
+		attDir = fmt.Sprintf("%s/%s", ref.Author, AttachmentsDir)
+	case AttachmentContainerKindManufacturer:
+		attDir = fmt.Sprintf("%s/%s", ref.Manufacturer, AttachmentsDir)
 	case AttachmentContainerKindTMID:
 		id, err := ParseTMID(ref.TMID)
 		if err != nil {

--- a/internal/model/toc_test.go
+++ b/internal/model/toc_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -147,6 +148,263 @@ func TestIndex_InsertAttachments(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, nameAtts, (*cnt).Attachments)
 
+	authorAtts := []Attachment{{
+		Name:      "LICENSE.txt",
+		MediaType: "text/plain",
+	}}
+	authorRef := NewAuthorAttachmentContainerRef("aut")
+	err = idx.InsertAttachments(authorRef, authorAtts...)
+	assert.NoError(t, err)
+	cnt, _, err = idx.FindAttachmentContainer(authorRef)
+	assert.NoError(t, err)
+	assert.Equal(t, authorAtts, (*cnt).Attachments)
+
+	manufacturerAtts := []Attachment{{
+		Name:      "MANUFACTURER_INFO.md",
+		MediaType: "Message/markdown",
+	}}
+	manufacturerRef := NewManufacturerAttachmentContainerRef("aut/man")
+	err = idx.InsertAttachments(manufacturerRef, manufacturerAtts...)
+	assert.NoError(t, err)
+	cnt, _, err = idx.FindAttachmentContainer(manufacturerRef)
+	assert.NoError(t, err)
+	assert.Equal(t, manufacturerAtts, (*cnt).Attachments)
+}
+
+func TestIndex_FetchAttachments(t *testing.T) {
+	idx := &Index{}
+	tmName := "aut/man/mpn"
+	id := tmName + "/v1.2.5-20231023121314-abcd12345678.tm.json"
+	err := idx.Insert(&ThingModel{
+		Manufacturer: SchemaManufacturer{Name: "man"},
+		Mpn:          "mpn",
+		Author:       SchemaAuthor{Name: "aut"},
+		Links:        []Link{{Rel: "original", HRef: "externalID"}},
+		ID:           id,
+		Description:  "descr",
+	})
+	assert.NoError(t, err)
+
+	atts := []Attachment{{
+		Name:      "README.md",
+		MediaType: "Message/markdown",
+	}, {
+		Name:      "User Guide.pdf",
+		MediaType: "application/pdf",
+	}}
+	idRef := NewTMIDAttachmentContainerRef(id)
+	err = idx.InsertAttachments(idRef, atts...)
+	assert.NoError(t, err)
+
+	nameAtts := []Attachment{{
+		Name:      "CHANGELOG.md",
+		MediaType: "Message/markdown",
+	}}
+	nameRef := NewTMNameAttachmentContainerRef(tmName)
+	err = idx.InsertAttachments(nameRef, nameAtts...)
+	assert.NoError(t, err)
+
+	authorAtts := []Attachment{{
+		Name:      "LICENSE.txt",
+		MediaType: "text/plain",
+	}}
+	authorRef := NewAuthorAttachmentContainerRef("aut")
+	err = idx.InsertAttachments(authorRef, authorAtts...)
+	assert.NoError(t, err)
+
+	manufacturerAtts := []Attachment{{
+		Name:      "MANUFACTURER_INFO.md",
+		MediaType: "Message/markdown",
+	}}
+	manufacturerRef := NewManufacturerAttachmentContainerRef("aut/man")
+	err = idx.InsertAttachments(manufacturerRef, manufacturerAtts...)
+	assert.NoError(t, err)
+
+	cnt, _, err := idx.FindAttachmentContainer(idRef)
+	assert.NoError(t, err)
+	att, found := cnt.FindAttachment("README.md")
+	assert.True(t, found)
+	assert.Equal(t, "README.md", att.Name)
+	assert.Equal(t, "Message/markdown", att.MediaType)
+
+	cnt, _, err = idx.FindAttachmentContainer(nameRef)
+	assert.NoError(t, err)
+	att, found = cnt.FindAttachment("CHANGELOG.md")
+	assert.True(t, found)
+	assert.Equal(t, "CHANGELOG.md", att.Name)
+	assert.Equal(t, "Message/markdown", att.MediaType)
+
+	cnt, _, err = idx.FindAttachmentContainer(authorRef)
+	assert.NoError(t, err)
+	att, found = cnt.FindAttachment("LICENSE.txt")
+	assert.True(t, found)
+	assert.Equal(t, "LICENSE.txt", att.Name)
+	assert.Equal(t, "text/plain", att.MediaType)
+
+	cnt, _, err = idx.FindAttachmentContainer(manufacturerRef)
+	assert.NoError(t, err)
+	att, found = cnt.FindAttachment("MANUFACTURER_INFO.md")
+	assert.True(t, found)
+	assert.Equal(t, "MANUFACTURER_INFO.md", att.Name)
+	assert.Equal(t, "Message/markdown", att.MediaType)
+
+	att, found = cnt.FindAttachment("NON_EXISTENT.txt")
+	assert.False(t, found)
+	assert.Equal(t, Attachment{}, att)
+}
+
+func TestIndex_DeleteAttachments(t *testing.T) {
+	idx := &Index{}
+	tmName := "aut/man/mpn"
+	id := tmName + "/v1.2.5-20231023121314-abcd12345678.tm.json"
+	err := idx.Insert(&ThingModel{
+		Manufacturer: SchemaManufacturer{Name: "man"},
+		Mpn:          "mpn",
+		Author:       SchemaAuthor{Name: "aut"},
+		Links:        []Link{{Rel: "original", HRef: "externalID"}},
+		ID:           id,
+		Description:  "descr",
+	})
+	assert.NoError(t, err)
+
+	atts := []Attachment{{
+		Name:      "README.md",
+		MediaType: "Message/markdown",
+	}, {
+		Name:      "User Guide.pdf",
+		MediaType: "application/pdf",
+	}}
+	idRef := NewTMIDAttachmentContainerRef(id)
+	err = idx.InsertAttachments(idRef, atts...)
+	assert.NoError(t, err)
+
+	nameAtts := []Attachment{{
+		Name:      "CHANGELOG.md",
+		MediaType: "Message/markdown",
+	}}
+	nameRef := NewTMNameAttachmentContainerRef(tmName)
+	err = idx.InsertAttachments(nameRef, nameAtts...)
+	assert.NoError(t, err)
+
+	authorAtts := []Attachment{{
+		Name:      "LICENSE.txt",
+		MediaType: "text/plain",
+	}}
+	authorRef := NewAuthorAttachmentContainerRef("aut")
+	err = idx.InsertAttachments(authorRef, authorAtts...)
+	assert.NoError(t, err)
+
+	manufacturerAtts := []Attachment{{
+		Name:      "MANUFACTURER_INFO.md",
+		MediaType: "Message/markdown",
+	}}
+	manufacturerRef := NewManufacturerAttachmentContainerRef("aut/man")
+	err = idx.InsertAttachments(manufacturerRef, manufacturerAtts...)
+	assert.NoError(t, err)
+
+	cnt, _, err := idx.FindAttachmentContainer(idRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(cnt.Attachments))
+	cnt.Attachments = slices.DeleteFunc(cnt.Attachments, func(att Attachment) bool {
+		return att.Name == "README.md"
+	})
+	assert.Equal(t, 1, len(cnt.Attachments))
+	assert.Equal(t, "User Guide.pdf", cnt.Attachments[0].Name)
+
+	cnt, _, err = idx.FindAttachmentContainer(nameRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	cnt.Attachments = slices.DeleteFunc(cnt.Attachments, func(att Attachment) bool {
+		return att.Name == "CHANGELOG.md"
+	})
+	assert.Equal(t, 0, len(cnt.Attachments))
+
+	cnt, _, err = idx.FindAttachmentContainer(authorRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	cnt.Attachments = slices.DeleteFunc(cnt.Attachments, func(att Attachment) bool {
+		return att.Name == "LICENSE.txt"
+	})
+	assert.Equal(t, 0, len(cnt.Attachments))
+
+	cnt, _, err = idx.FindAttachmentContainer(manufacturerRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	cnt.Attachments = slices.DeleteFunc(cnt.Attachments, func(att Attachment) bool {
+		return att.Name == "MANUFACTURER_INFO.md"
+	})
+	assert.Equal(t, 0, len(cnt.Attachments))
+}
+
+func TestIndex_ListAttachments(t *testing.T) {
+	idx := &Index{}
+	tmName := "aut/man/mpn"
+	id := tmName + "/v1.2.5-20231023121314-abcd12345678.tm.json"
+	err := idx.Insert(&ThingModel{
+		Manufacturer: SchemaManufacturer{Name: "man"},
+		Mpn:          "mpn",
+		Author:       SchemaAuthor{Name: "aut"},
+		Links:        []Link{{Rel: "original", HRef: "externalID"}},
+		ID:           id,
+		Description:  "descr",
+	})
+	assert.NoError(t, err)
+
+	atts := []Attachment{{
+		Name:      "README.md",
+		MediaType: "Message/markdown",
+	}, {
+		Name:      "User Guide.pdf",
+		MediaType: "application/pdf",
+	}}
+	idRef := NewTMIDAttachmentContainerRef(id)
+	err = idx.InsertAttachments(idRef, atts...)
+	assert.NoError(t, err)
+
+	nameAtts := []Attachment{{
+		Name:      "CHANGELOG.md",
+		MediaType: "Message/markdown",
+	}}
+	nameRef := NewTMNameAttachmentContainerRef(tmName)
+	err = idx.InsertAttachments(nameRef, nameAtts...)
+	assert.NoError(t, err)
+
+	authorAtts := []Attachment{{
+		Name:      "LICENSE.txt",
+		MediaType: "text/plain",
+	}}
+	authorRef := NewAuthorAttachmentContainerRef("aut")
+	err = idx.InsertAttachments(authorRef, authorAtts...)
+	assert.NoError(t, err)
+
+	manufacturerAtts := []Attachment{{
+		Name:      "MANUFACTURER_INFO.md",
+		MediaType: "Message/markdown",
+	}}
+	manufacturerRef := NewManufacturerAttachmentContainerRef("aut/man")
+	err = idx.InsertAttachments(manufacturerRef, manufacturerAtts...)
+	assert.NoError(t, err)
+
+	cnt, _, err := idx.FindAttachmentContainer(idRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(cnt.Attachments))
+	assert.Equal(t, "README.md", cnt.Attachments[0].Name)
+	assert.Equal(t, "User Guide.pdf", cnt.Attachments[1].Name)
+
+	cnt, _, err = idx.FindAttachmentContainer(nameRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	assert.Equal(t, "CHANGELOG.md", cnt.Attachments[0].Name)
+
+	cnt, _, err = idx.FindAttachmentContainer(authorRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	assert.Equal(t, "LICENSE.txt", cnt.Attachments[0].Name)
+
+	cnt, _, err = idx.FindAttachmentContainer(manufacturerRef)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cnt.Attachments))
+	assert.Equal(t, "MANUFACTURER_INFO.md", cnt.Attachments[0].Name)
 }
 func TestIndex_Insert(t *testing.T) {
 	idx := &Index{}
@@ -161,7 +419,7 @@ func TestIndex_Insert(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(idx.Data))
+	assert.Equal(t, 3, len(idx.Data))
 	assert.Equal(t, "aut/man/mpn", idx.Data[0].Name)
 	assert.Equal(t, 1, len(idx.Data[0].Versions))
 	err = idx.InsertAttachments(NewTMIDAttachmentContainerRef("aut/man/mpn/v1.2.5-20231023121314-abcd12345678.tm.json"), Attachment{Name: "README.md", MediaType: "Message/markdown"}, Attachment{Name: "User Guide.pdf", MediaType: "application/pdf"})
@@ -188,7 +446,7 @@ func TestIndex_Insert(t *testing.T) {
 		Description:  "descr",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(idx.Data))
+	assert.Equal(t, 3, len(idx.Data))
 	assert.Equal(t, 2, len(idx.Data[0].Versions))
 
 	err = idx.Insert(&ThingModel{
@@ -200,10 +458,10 @@ func TestIndex_Insert(t *testing.T) {
 		Description:  "descr",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(idx.Data))
-	assert.Equal(t, "aut/man/mpn/opt", idx.Data[1].Name)
+	assert.Equal(t, 4, len(idx.Data))
+	assert.Equal(t, "aut/man/mpn/opt", idx.Data[3].Name)
 	assert.Equal(t, 2, len(idx.Data[0].Versions))
-	assert.Equal(t, 1, len(idx.Data[1].Versions))
+	assert.Equal(t, 1, len(idx.Data[3].Versions))
 }
 
 func TestIndex_Delete(t *testing.T) {

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -831,6 +831,8 @@ func (f *FileRepo) fullIndexRebuild(ctx context.Context, oldIndex *model.Index, 
 			names = append(names, id.Name)
 			updatedAttContainers[model.NewTMIDAttachmentContainerRef(id.String())] = struct{}{}
 			updatedAttContainers[model.NewTMNameAttachmentContainerRef(id.Name)] = struct{}{}
+			updatedAttContainers[model.NewAuthorAttachmentContainerRef(strings.Split(id.Name, "/")[0])] = struct{}{}
+			updatedAttContainers[model.NewManufacturerAttachmentContainerRef(strings.Split(id.Name, "/")[0]+"/"+strings.Split(id.Name, "/")[1])] = struct{}{}
 		}
 		return nil
 	})

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -268,14 +268,17 @@ func (f *FileRepo) Fetch(ctx context.Context, id string) (string, []byte, error)
 func (f *FileRepo) Index(ctx context.Context, ids ...string) error {
 	err := f.checkRootValid()
 	if err != nil {
+		fmt.Println("Root invalid:", err)
 		return err
 	}
 	unlock, err := f.lockIndex(ctx)
 	defer unlock()
 	if err != nil {
+		fmt.Println("Could not acquire index lock:", err)
 		return err
 	}
 
+	fmt.Println("Updating index...")
 	if len(ids) == 0 {
 		_, err = f.updateIndex(ctx, f.fullIndexRebuild)
 		return err
@@ -666,6 +669,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	oldNames := f.readNamesFile()
 	oldIndex, err := f.readIndex()
 	if err != nil {
+		fmt.Println("No existing index found, starting from empty index")
 		oldIndex = &model.Index{
 			Meta: model.IndexMeta{Created: time.Now()},
 			Data: []*model.IndexEntry{},
@@ -674,6 +678,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 
 	newIndex, names, fileCount, err := updater(ctx, oldIndex, oldNames)
 	if err != nil {
+		fmt.Println("Error while updating index:", err)
 		return nil, err
 	}
 
@@ -686,6 +691,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	newIndexJson, _ := json.MarshalIndent(newIndex, "", "  ")
 	err = utils.AtomicWriteFile(f.indexFilename(), newIndexJson, defaultFilePermissions)
 	if err != nil {
+		fmt.Println("Error while writing index:", err)
 		return nil, err
 	}
 	for _, d := range newIndex.Data {

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -268,17 +268,14 @@ func (f *FileRepo) Fetch(ctx context.Context, id string) (string, []byte, error)
 func (f *FileRepo) Index(ctx context.Context, ids ...string) error {
 	err := f.checkRootValid()
 	if err != nil {
-		fmt.Println("Root invalid:", err)
 		return err
 	}
 	unlock, err := f.lockIndex(ctx)
 	defer unlock()
 	if err != nil {
-		fmt.Println("Could not acquire index lock:", err)
 		return err
 	}
 
-	fmt.Println("Updating index...")
 	if len(ids) == 0 {
 		_, err = f.updateIndex(ctx, f.fullIndexRebuild)
 		return err
@@ -669,7 +666,6 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	oldNames := f.readNamesFile()
 	oldIndex, err := f.readIndex()
 	if err != nil {
-		fmt.Println("No existing index found, starting from empty index")
 		oldIndex = &model.Index{
 			Meta: model.IndexMeta{Created: time.Now()},
 			Data: []*model.IndexEntry{},
@@ -678,7 +674,6 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 
 	newIndex, names, fileCount, err := updater(ctx, oldIndex, oldNames)
 	if err != nil {
-		fmt.Println("Error while updating index:", err)
 		return nil, err
 	}
 
@@ -691,7 +686,6 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	newIndexJson, _ := json.MarshalIndent(newIndex, "", "  ")
 	err = utils.AtomicWriteFile(f.indexFilename(), newIndexJson, defaultFilePermissions)
 	if err != nil {
-		fmt.Println("Error while writing index:", err)
 		return nil, err
 	}
 	for _, d := range newIndex.Data {

--- a/internal/repos/fs.go
+++ b/internal/repos/fs.go
@@ -139,7 +139,7 @@ func (f *FileRepo) Delete(ctx context.Context, id string) error {
 	}
 	_ = rmEmptyDirs(dir, f.root)
 
-	_, err = f.updateIndex(ctx, f.indexUpdaterForIds(id))
+	_, _, _, _, err = f.updateIndex(ctx, f.indexUpdaterForIds(id))
 	return err
 }
 
@@ -265,23 +265,23 @@ func (f *FileRepo) Fetch(ctx context.Context, id string) (string, []byte, error)
 	return actualId, b, err
 }
 
-func (f *FileRepo) Index(ctx context.Context, ids ...string) error {
-	err := f.checkRootValid()
+func (f *FileRepo) Index(ctx context.Context, ids ...string) (authorsList, manufacturersList, mpnsList []string, err error) {
+	err = f.checkRootValid()
 	if err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 	unlock, err := f.lockIndex(ctx)
 	defer unlock()
 	if err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 
 	if len(ids) == 0 {
-		_, err = f.updateIndex(ctx, f.fullIndexRebuild)
-		return err
+		_, aut, man, mpns, err := f.updateIndex(ctx, f.fullIndexRebuild)
+		return aut, man, mpns, err
 	}
-	_, err = f.updateIndex(ctx, f.indexUpdaterForIds(ids...))
-	return err
+	_, aut, man, mpns, err := f.updateIndex(ctx, f.indexUpdaterForIds(ids...))
+	return aut, man, mpns, err
 }
 
 func (f *FileRepo) CheckIntegrity(ctx context.Context, filter model.ResourceFilter) (results []model.CheckResult, err error) {
@@ -429,7 +429,7 @@ func (f *FileRepo) ImportAttachment(ctx context.Context, container model.Attachm
 		return err
 	}
 
-	_, err = f.updateIndex(ctx, f.indexUpdaterForImportAttachment(container, attachment, content))
+	_, _, _, _, err = f.updateIndex(ctx, f.indexUpdaterForImportAttachment(container, attachment, content))
 	if err != nil {
 		return err
 	}
@@ -521,7 +521,7 @@ func (f *FileRepo) DeleteAttachment(ctx context.Context, ref model.AttachmentCon
 		return err
 	}
 
-	_, err = f.updateIndex(ctx, f.indexUpdaterForDeleteAttachment(ref, attachmentName))
+	_, _, _, _, err = f.updateIndex(ctx, f.indexUpdaterForDeleteAttachment(ref, attachmentName))
 	if err != nil {
 		return err
 	}
@@ -656,7 +656,7 @@ func makeAbs(dir string) (string, error) {
 	}
 }
 
-func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*model.Index, error) {
+func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (index *model.Index, authorsList, manufacturersList, mpnsList []string, err error) {
 	// Prepare data collection for logging stats
 	var authors []string
 	var manufacturers []string
@@ -674,7 +674,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 
 	newIndex, names, fileCount, err := updater(ctx, oldIndex, oldNames)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 
 	newIndex.Sort()
@@ -686,7 +686,7 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	newIndexJson, _ := json.MarshalIndent(newIndex, "", "  ")
 	err = utils.AtomicWriteFile(f.indexFilename(), newIndexJson, defaultFilePermissions)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	for _, d := range newIndex.Data {
 		if !slices.Contains(authors, d.Author.Name) {
@@ -701,25 +701,25 @@ func (f *FileRepo) updateIndex(ctx context.Context, updater indexUpdater) (*mode
 	}
 	err = f.writeHelperTxtFile(names, TmNamesFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = f.writeHelperTxtFile(authors, TmAuthorsFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = f.writeHelperTxtFile(manufacturers, TmManufacturersFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = f.writeHelperTxtFile(mpns, TmMpnsFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 
 	msg := fmt.Sprintf("Updated index with %d records in %s ", fileCount, duration.String())
 	utils.GetLogger(ctx, "FileRepo").Debug(msg)
 
-	return newIndex, nil
+	return newIndex, authors, manufacturers, mpns, nil
 }
 
 type indexUpdater func(ctx context.Context, oldIndex *model.Index, oldNames []string) (newIndex *model.Index, newNames []string, updatedFileCount int, err error)

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -354,10 +354,12 @@ func TestFileRepo_Index(t *testing.T) {
 		assert.NoError(t, err)
 		zeroTime := time.Time{}
 		assert.True(t, idx.Meta.Created.After(zeroTime))
-		assert.Equal(t, 1, len(idx.Data))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[0].Name)
-		assert.Equal(t, 1, len(idx.Data[0].Versions))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json", idx.Data[0].Versions[0].TMID)
+		assert.Equal(t, 3, len(idx.Data))
+		assert.Equal(t, "omnicorp-tm-department", idx.Data[0].Name)
+		assert.Equal(t, "omnicorp-tm-department/omnicorp", idx.Data[1].Name)
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[2].Name)
+		assert.Equal(t, 1, len(idx.Data[2].Versions))
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json", idx.Data[2].Versions[0].TMID)
 
 		names := r.readNamesFile()
 		assert.Equal(t, []string{"omnicorp-tm-department/omnicorp/omnilamp/subfolder"}, names)
@@ -369,9 +371,9 @@ func TestFileRepo_Index(t *testing.T) {
 
 		idx, err := r.readIndex()
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(idx.Data))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[0].Name)
-		assert.Equal(t, 2, len(idx.Data[0].Versions))
+		assert.Equal(t, 3, len(idx.Data))
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[2].Name)
+		assert.Equal(t, 2, len(idx.Data[2].Versions))
 		names := r.readNamesFile()
 		assert.Equal(t, []string{"omnicorp-tm-department/omnicorp/omnilamp/subfolder"}, names)
 	})
@@ -382,7 +384,7 @@ func TestFileRepo_Index(t *testing.T) {
 
 		idx, err := r.readIndex()
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 		names := r.readNamesFile()
 		assert.Equal(t, []string{
 			"omnicorp-tm-department/omnicorp/omnilamp",
@@ -407,7 +409,7 @@ func TestFileRepo_Index(t *testing.T) {
 
 		idx, err := r.readIndex()
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 		names := r.readNamesFile()
 		assert.Equal(t, []string{
 			"omnicorp-tm-department/omnicorp/omnilamp",
@@ -451,15 +453,15 @@ func TestFileRepo_Index(t *testing.T) {
 
 		idx, err := r.readIndex()
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 
-		assert.Equal(t, tmName1, idx.Data[0].Name)
-		assert.Equal(t, tmId13, idx.Data[0].Versions[0].TMID)
-		assert.Equal(t, tmId12, idx.Data[0].Versions[1].TMID)
-		assert.Equal(t, tmId11, idx.Data[0].Versions[2].TMID)
-		assert.Equal(t, tmName2, idx.Data[1].Name)
-		assert.Equal(t, tmId22, idx.Data[1].Versions[0].TMID)
-		assert.Equal(t, tmId21, idx.Data[1].Versions[1].TMID)
+		assert.Equal(t, tmName1, idx.Data[2].Name)
+		assert.Equal(t, tmId13, idx.Data[2].Versions[0].TMID)
+		assert.Equal(t, tmId12, idx.Data[2].Versions[1].TMID)
+		assert.Equal(t, tmId11, idx.Data[2].Versions[2].TMID)
+		assert.Equal(t, tmName2, idx.Data[3].Name)
+		assert.Equal(t, tmId22, idx.Data[3].Versions[0].TMID)
+		assert.Equal(t, tmId21, idx.Data[3].Versions[1].TMID)
 	})
 }
 
@@ -635,8 +637,8 @@ func TestFileRepo_Index_Parallel(t *testing.T) {
 	idx, err := r.readIndex()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(idx.Data))
-	assert.Equal(t, N, len(idx.Data[0].Versions))
+	assert.Equal(t, 3, len(idx.Data))
+	assert.Equal(t, N, len(idx.Data[2].Versions))
 	names := r.readNamesFile()
 	assert.Equal(t, 1, len(names))
 }

--- a/internal/repos/fs_test.go
+++ b/internal/repos/fs_test.go
@@ -290,7 +290,8 @@ func TestFileRepo_Delete(t *testing.T) {
 				root: test.root,
 				spec: spec,
 			}
-			assert.NoError(t, r.Index(context.Background()))
+			_, _, _, err := r.Index(context.Background())
+			assert.NoError(t, err)
 
 			t.Run("invalid id", func(t *testing.T) {
 				err := r.Delete(context.Background(), "invalid-id")
@@ -347,7 +348,7 @@ func TestFileRepo_Index(t *testing.T) {
 	}
 
 	t.Run("single id/no index file", func(t *testing.T) {
-		err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json")
+		_, _, _, err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json")
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -366,7 +367,7 @@ func TestFileRepo_Index(t *testing.T) {
 
 	})
 	t.Run("single id/existing index file", func(t *testing.T) {
-		err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
+		_, _, _, err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -379,7 +380,7 @@ func TestFileRepo_Index(t *testing.T) {
 	})
 
 	t.Run("full update/existing index file", func(t *testing.T) {
-		err := r.Index(context.Background())
+		_, _, _, err := r.Index(context.Background())
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -404,7 +405,7 @@ func TestFileRepo_Index(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, r.writeHelperTxtFile(nil, TmNamesFile))
 
-		err = r.Index(context.Background())
+		_, _, _, err = r.Index(context.Background())
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -423,7 +424,7 @@ func TestFileRepo_Index(t *testing.T) {
 		assert.NoError(t, os.MkdirAll(attDir, defaultDirPermissions))
 		assert.NoError(t, os.WriteFile(filepath.Join(attDir, "README.txt"), []byte("Read This, or Else"), defaultFilePermissions))
 
-		err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
+		_, _, _, err := r.Index(context.Background(), "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -448,7 +449,7 @@ func TestFileRepo_Index(t *testing.T) {
 		tmId22 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
 
 		// update index with unordered ID's
-		err = r.Index(context.Background(), tmId21, tmId12, tmId22, tmId13, tmId11)
+		_, _, _, err = r.Index(context.Background(), tmId21, tmId12, tmId22, tmId13, tmId11)
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex()
@@ -506,12 +507,12 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				root: test.root,
 				spec: spec,
 			}
-			err := r.Index(context.Background())
+			_, _, _, err := r.Index(context.Background())
 			assert.NoError(t, err)
 
 			t.Run("non-existing id", func(t *testing.T) {
 				// when: deleting a non-existing id from index
-				err := r.Index(context.Background())
+				_, _, _, err := r.Index(context.Background())
 				index, err := r.readIndex()
 				assert.NoError(t, err)
 				// then: nothing changes
@@ -527,7 +528,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 			})
 			t.Run("existing id and file", func(t *testing.T) {
 				// when: updating index for TM that has not been removed from disk
-				err := r.Index(context.Background())
+				_, _, _, err := r.Index(context.Background())
 				assert.NoError(t, err)
 				index, err := r.readIndex()
 				assert.NoError(t, err)
@@ -546,7 +547,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				// given: a deleted TM file
 				_ = os.Remove(filepath.Join(r.root, "omnicorp-tm-department/omnicorp/omnilamp/v0.0.0-20240409155220-e414b33a9edf.tm.json"))
 				// when: updating index for the TM
-				err := r.Index(context.Background())
+				_, _, _, err := r.Index(context.Background())
 				assert.NoError(t, err)
 				index, err := r.readIndex()
 				assert.NoError(t, err)
@@ -566,7 +567,7 @@ func TestFileRepo_UpdateIndex_RemoveId(t *testing.T) {
 				id := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
 				assert.NoError(t, os.Remove(filepath.Join(r.root, id)))
 				// when: updating index for the id
-				err = r.Index(context.Background())
+				_, _, _, err = r.Index(context.Background())
 				assert.NoError(t, err)
 				index, err := r.readIndex()
 				assert.NoError(t, err)
@@ -628,7 +629,7 @@ func TestFileRepo_Index_Parallel(t *testing.T) {
 			date := firstDate.Add(time.Duration(v) * 1 * time.Second).Format(model.PseudoVersionTimestampFormat)
 			b := make([]byte, 6)
 			_, _ = rand.Read(b)
-			err := r.Index(context.Background(), fmt.Sprintf("author/manuf/mpn/v1.0.%d-%s-%x.tm.json", v, date, b))
+			_, _, _, err := r.Index(context.Background(), fmt.Sprintf("author/manuf/mpn/v1.0.%d-%s-%x.tm.json", v, date, b))
 			assert.NoError(t, err)
 			wg.Done()
 		}(i)
@@ -742,7 +743,7 @@ func TestFileRepo_CheckIntegrity(t *testing.T) {
 			root: temp,
 			spec: spec,
 		}
-		_ = r.Index(context.Background())
+		_, _, _, _ = r.Index(context.Background())
 		// when checking the integrity
 		res, err := r.CheckIntegrity(context.Background(), nil)
 

--- a/internal/repos/http.go
+++ b/internal/repos/http.go
@@ -75,8 +75,8 @@ func (h *HttpRepo) buildUrl(fileId string) string {
 	return h.parsedRoot.JoinPath(fileId).String()
 }
 
-func (h *HttpRepo) Index(context.Context, ...string) error {
-	return ErrNotSupported
+func (h *HttpRepo) Index(context.Context, ...string) (authorsList, manufacturersList, mpnsList []string, err error) {
+	return nil, nil, nil, ErrNotSupported
 }
 
 func (h *HttpRepo) CheckIntegrity(ctx context.Context, filter model.ResourceFilter) (results []model.CheckResult, err error) {

--- a/internal/repos/mocks/Repo.go
+++ b/internal/repos/mocks/Repo.go
@@ -244,7 +244,7 @@ func (_m *Repo) ImportAttachment(ctx context.Context, container model.Attachment
 }
 
 // Index provides a mock function with given fields: ctx, updatedIds
-func (_m *Repo) Index(ctx context.Context, updatedIds ...string) error {
+func (_m *Repo) Index(ctx context.Context, updatedIds ...string) ([]string, []string, []string, error) {
 	_va := make([]interface{}, len(updatedIds))
 	for _i := range updatedIds {
 		_va[_i] = updatedIds[_i]
@@ -258,14 +258,44 @@ func (_m *Repo) Index(ctx context.Context, updatedIds ...string) error {
 		panic("no return value specified for Index")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, ...string) error); ok {
+	var r0 []string
+	var r1 []string
+	var r2 []string
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) ([]string, []string, []string, error)); ok {
+		return rf(ctx, updatedIds...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) []string); ok {
 		r0 = rf(ctx, updatedIds...)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, ...string) []string); ok {
+		r1 = rf(ctx, updatedIds...)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, ...string) []string); ok {
+		r2 = rf(ctx, updatedIds...)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(3).(func(context.Context, ...string) error); ok {
+		r3 = rf(ctx, updatedIds...)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // List provides a mock function with given fields: ctx, search

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -135,7 +135,7 @@ type Repo interface {
 	Fetch(ctx context.Context, id string) (string, []byte, error)
 	// Index updates repository's index file with data from given TM files. For ids that refer to non-existing files,
 	// removes those from index. Performs a full update if no updatedIds given
-	Index(ctx context.Context, updatedIds ...string) error
+	Index(ctx context.Context, updatedIds ...string) (authors, manufacturers, mpns []string, err error)
 	// CheckIntegrity checks the internal resources for integrity and consistency
 	CheckIntegrity(ctx context.Context, filter model.ResourceFilter) (results []model.CheckResult, err error)
 	// List searches the catalog for TMs matching search parameters

--- a/internal/repos/s3.go
+++ b/internal/repos/s3.go
@@ -715,6 +715,8 @@ func (s *S3Repo) fullIndexRebuild(ctx context.Context, oldIndex *model.Index, _ 
 			names = append(names, id.Name)
 			updatedAttContainers[model.NewTMIDAttachmentContainerRef(id.String())] = struct{}{}
 			updatedAttContainers[model.NewTMNameAttachmentContainerRef(id.Name)] = struct{}{}
+			updatedAttContainers[model.NewAuthorAttachmentContainerRef(strings.Split(id.Name, "/")[0])] = struct{}{}
+			updatedAttContainers[model.NewManufacturerAttachmentContainerRef(strings.Split(id.Name, "/")[0]+"/"+strings.Split(id.Name, "/")[1])] = struct{}{}
 		}
 	}
 

--- a/internal/repos/s3.go
+++ b/internal/repos/s3.go
@@ -199,7 +199,7 @@ func (s *S3Repo) Delete(ctx context.Context, id string) error {
 		}
 	}
 
-	_, err = s.updateIndex(ctx, s.indexUpdaterForIds(id))
+	_, _, _, _, err = s.updateIndex(ctx, s.indexUpdaterForIds(id))
 	return err
 }
 
@@ -278,20 +278,20 @@ func (s *S3Repo) Fetch(ctx context.Context, id string) (string, []byte, error) {
 	return actualId, b, err
 }
 
-func (s *S3Repo) Index(ctx context.Context, ids ...string) error {
+func (s *S3Repo) Index(ctx context.Context, ids ...string) (authors, manufacturers, mpns []string, err error) {
 
 	unlock, err := s.lockIndex(ctx)
 	defer unlock()
 	if err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 
 	if len(ids) == 0 {
-		_, err = s.updateIndex(ctx, s.fullIndexRebuild)
-		return err
+		_, aut, man, mpns, err := s.updateIndex(ctx, s.fullIndexRebuild)
+		return aut, man, mpns, err
 	}
-	_, err = s.updateIndex(ctx, s.indexUpdaterForIds(ids...))
-	return err
+	_, aut, man, mpns, err := s.updateIndex(ctx, s.indexUpdaterForIds(ids...))
+	return aut, man, mpns, err
 }
 
 func (s *S3Repo) CheckIntegrity(ctx context.Context, filter model.ResourceFilter) (results []model.CheckResult, err error) {
@@ -422,7 +422,7 @@ func (s *S3Repo) ImportAttachment(ctx context.Context, container model.Attachmen
 		return err
 	}
 
-	_, err = s.updateIndex(ctx, s.indexUpdaterForImportAttachment(container, attachment, content))
+	_, _, _, _, err = s.updateIndex(ctx, s.indexUpdaterForImportAttachment(container, attachment, content))
 	if err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (s *S3Repo) DeleteAttachment(ctx context.Context, ref model.AttachmentConta
 		return err
 	}
 
-	_, err = s.updateIndex(ctx, s.indexUpdaterForDeleteAttachment(ref, attachmentName))
+	_, _, _, _, err = s.updateIndex(ctx, s.indexUpdaterForDeleteAttachment(ref, attachmentName))
 	if err != nil {
 		return err
 	}
@@ -542,7 +542,7 @@ func (s *S3Repo) getAttachmentsDir(ref model.AttachmentContainerRef) (string, er
 	return model.RelAttachmentsDir(ref)
 }
 
-func (s *S3Repo) updateIndex(ctx context.Context, updater indexUpdater) (*model.Index, error) {
+func (s *S3Repo) updateIndex(ctx context.Context, updater indexUpdater) (index *model.Index, authorsList, manufacturersList, mpnsList []string, err error) {
 	// Prepare data collection for logging stats
 	var authors []string
 	var manufacturers []string
@@ -560,7 +560,7 @@ func (s *S3Repo) updateIndex(ctx context.Context, updater indexUpdater) (*model.
 
 	newIndex, names, fileCount, err := updater(ctx, oldIndex, oldNames)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 
 	newIndex.Sort()
@@ -571,7 +571,7 @@ func (s *S3Repo) updateIndex(ctx context.Context, updater indexUpdater) (*model.
 	newIndexJson, _ := json.MarshalIndent(newIndex, "", "  ")
 	err = s3WriteObject(ctx, s.client, s.bucket, s.indexFilename(), newIndexJson)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	for _, d := range newIndex.Data {
 		if !slices.Contains(authors, d.Author.Name) {
@@ -586,25 +586,25 @@ func (s *S3Repo) updateIndex(ctx context.Context, updater indexUpdater) (*model.
 	}
 	err = s.writeHelperTxtFile(ctx, names, TmNamesFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = s.writeHelperTxtFile(ctx, authors, TmAuthorsFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = s.writeHelperTxtFile(ctx, manufacturers, TmManufacturersFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 	err = s.writeHelperTxtFile(ctx, mpns, TmMpnsFile)
 	if err != nil {
-		return nil, err
+		return nil, authors, manufacturers, mpns, err
 	}
 
 	msg := fmt.Sprintf("Updated index with %d records in %s ", fileCount, duration.String())
 	utils.GetLogger(ctx, "S3Repo").Debug(msg)
 
-	return newIndex, nil
+	return newIndex, authors, manufacturers, mpns, nil
 }
 
 func (s *S3Repo) indexUpdaterForIds(ids ...string) indexUpdater {

--- a/internal/repos/s3_test.go
+++ b/internal/repos/s3_test.go
@@ -443,11 +443,11 @@ func TestS3Repo_Index(t *testing.T) {
 		zeroTime := time.Time{}
 		assert.True(t, idx.Meta.Created.After(zeroTime))
 		// and then: index contains one ThingModel
-		assert.Equal(t, 1, len(idx.Data))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[0].Name)
+		assert.Equal(t, 3, len(idx.Data))
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[2].Name)
 		// and then: the ThingModel contains one version
-		assert.Equal(t, 1, len(idx.Data[0].Versions))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json", idx.Data[0].Versions[0].TMID)
+		assert.Equal(t, 1, len(idx.Data[2].Versions))
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json", idx.Data[2].Versions[0].TMID)
 		// and then: the names file is created
 		names := r.readNamesFile(ctx)
 		assert.Equal(t, []string{"omnicorp-tm-department/omnicorp/omnilamp/subfolder"}, names)
@@ -462,10 +462,12 @@ func TestS3Repo_Index(t *testing.T) {
 		idx, err := r.readIndex(ctx)
 		assert.NoError(t, err)
 		// and then: index contains one ThingModel
-		assert.Equal(t, 1, len(idx.Data))
-		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[0].Name)
+		assert.Equal(t, 3, len(idx.Data))
+		assert.Equal(t, "omnicorp-tm-department", idx.Data[0].Name)
+		assert.Equal(t, "omnicorp-tm-department/omnicorp", idx.Data[1].Name)
+		assert.Equal(t, "omnicorp-tm-department/omnicorp/omnilamp/subfolder", idx.Data[2].Name)
 		// and then: the ThingModel contains two versions
-		assert.Equal(t, 2, len(idx.Data[0].Versions))
+		assert.Equal(t, 2, len(idx.Data[2].Versions))
 		// and then: the names file is readable
 		names := r.readNamesFile(ctx)
 		assert.Equal(t, []string{"omnicorp-tm-department/omnicorp/omnilamp/subfolder"}, names)
@@ -480,7 +482,7 @@ func TestS3Repo_Index(t *testing.T) {
 		idx, err := r.readIndex(ctx)
 		assert.NoError(t, err)
 		// and then: index contains now two ThingModels
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 		// and then: the names file is readable
 		names := r.readNamesFile(ctx)
 		assert.Equal(t, []string{
@@ -510,7 +512,7 @@ func TestS3Repo_Index(t *testing.T) {
 		idx, err := r.readIndex(ctx)
 		assert.NoError(t, err)
 		// and then: index contains now two ThingModels
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 		names := r.readNamesFile(ctx)
 		assert.Equal(t, []string{
 			"omnicorp-tm-department/omnicorp/omnilamp",
@@ -556,15 +558,15 @@ func TestS3Repo_Index(t *testing.T) {
 
 		idx, err := r.readIndex(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(idx.Data))
+		assert.Equal(t, 4, len(idx.Data))
 
-		assert.Equal(t, tmName1, idx.Data[0].Name)
-		assert.Equal(t, tmId13, idx.Data[0].Versions[0].TMID)
-		assert.Equal(t, tmId12, idx.Data[0].Versions[1].TMID)
-		assert.Equal(t, tmId11, idx.Data[0].Versions[2].TMID)
-		assert.Equal(t, tmName2, idx.Data[1].Name)
-		assert.Equal(t, tmId22, idx.Data[1].Versions[0].TMID)
-		assert.Equal(t, tmId21, idx.Data[1].Versions[1].TMID)
+		assert.Equal(t, tmName1, idx.Data[2].Name)
+		assert.Equal(t, tmId13, idx.Data[2].Versions[0].TMID)
+		assert.Equal(t, tmId12, idx.Data[2].Versions[1].TMID)
+		assert.Equal(t, tmId11, idx.Data[2].Versions[2].TMID)
+		assert.Equal(t, tmName2, idx.Data[3].Name)
+		assert.Equal(t, tmId22, idx.Data[3].Versions[0].TMID)
+		assert.Equal(t, tmId21, idx.Data[3].Versions[1].TMID)
 	})
 }
 

--- a/internal/repos/s3_test.go
+++ b/internal/repos/s3_test.go
@@ -367,7 +367,8 @@ func TestS3Repo_Delete(t *testing.T) {
 	r := S3Repo{bucket: bucket, client: c}
 	ctx := context.Background()
 	// and given: the repo has an index
-	assert.NoError(t, r.Index(ctx))
+	_, _, _, err := r.Index(ctx)
+	assert.NoError(t, err)
 
 	t.Run("invalid id", func(t *testing.T) {
 		err := r.Delete(ctx, "invalid-id")
@@ -434,7 +435,7 @@ func TestS3Repo_Index(t *testing.T) {
 
 	t.Run("single id/no index file", func(t *testing.T) {
 		// when: index the repo with a single id
-		err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json")
+		_, _, _, err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v0.0.0-20240409155220-80424c65e4e6.tm.json")
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the index is created
@@ -455,7 +456,7 @@ func TestS3Repo_Index(t *testing.T) {
 
 	t.Run("single id/existing index file", func(t *testing.T) {
 		// when: index the repo with another version
-		err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
+		_, _, _, err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the index is readable
@@ -475,7 +476,7 @@ func TestS3Repo_Index(t *testing.T) {
 
 	t.Run("full update/existing index file", func(t *testing.T) {
 		// when: full index the repo with all found ThingModels in the repo
-		err := r.Index(ctx)
+		_, _, _, err := r.Index(ctx)
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the index is readable
@@ -505,7 +506,7 @@ func TestS3Repo_Index(t *testing.T) {
 		assert.NoError(t, r.writeHelperTxtFile(ctx, nil, ""))
 
 		// when: full index the repo with all found ThingModels in the repo
-		err = r.Index(ctx)
+		_, _, _, err = r.Index(ctx)
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the index is readable
@@ -526,7 +527,7 @@ func TestS3Repo_Index(t *testing.T) {
 		assert.NoError(t, os.WriteFile(attPath, []byte("Read This, or Else"), defaultFilePermissions))
 
 		// when: index the repo with a single id
-		err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
+		_, _, _, err := r.Index(ctx, "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json")
 		// then: there is no error
 		assert.NoError(t, err)
 		// and then: the index is readable
@@ -553,7 +554,7 @@ func TestS3Repo_Index(t *testing.T) {
 		tmId22 := "omnicorp-tm-department/omnicorp/omnilamp/subfolder/v3.2.1-20240409155220-3f779458e453.tm.json"
 
 		// update index with unordered ID's
-		err = r.Index(ctx, tmId21, tmId12, tmId22, tmId13, tmId11)
+		_, _, _, err = r.Index(ctx, tmId21, tmId12, tmId22, tmId13, tmId11)
 		assert.NoError(t, err)
 
 		idx, err := r.readIndex(ctx)
@@ -769,7 +770,7 @@ func TestS3Repo_CheckIntegrity(t *testing.T) {
 
 		// given: a clean repository with index
 		r := S3Repo{bucket: bucket, client: c}
-		_ = r.Index(ctx)
+		_, _, _, _ = r.Index(ctx)
 
 		// when checking the integrity
 		res, err := r.CheckIntegrity(ctx, nil)

--- a/internal/repos/tmc.go
+++ b/internal/repos/tmc.go
@@ -326,8 +326,8 @@ func (t *TmcRepo) Fetch(ctx context.Context, id string) (string, []byte, error) 
 	return t.fetchTM(ctx, reqUrl.String())
 }
 
-func (t *TmcRepo) Index(context.Context, ...string) error {
-	return nil // ignore request to update index as index updates are presumed to be handled by the underlying repo
+func (t *TmcRepo) Index(context.Context, ...string) (authorsList, manufacturersList, mpnsList []string, err error) {
+	return nil, nil, nil, nil // ignore request to update index as index updates are presumed to be handled by the underlying repo
 }
 
 func (t *TmcRepo) CheckIntegrity(ctx context.Context, filter model.ResourceFilter) (results []model.CheckResult, err error) {

--- a/internal/repos/tmc_test.go
+++ b/internal/repos/tmc_test.go
@@ -100,7 +100,7 @@ func TestTmcRepo_UpdateIndex(t *testing.T) {
 	config, _ := createTmcRepoConfig([]byte(`{"loc":"http://example.com", "type":"tmc"}`))
 	r, err := NewTmcRepo(config, model.NewRepoSpec("nameless"))
 	assert.NoError(t, err)
-	err = r.Index(context.Background())
+	_, _, _, err = r.Index(context.Background())
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
to be fixed:
- [x] list for manufacturer
- [x] list is currently case-sensetive, import/fetch/delete - not

examples:
```
attachment import author test1.txt -t author -r repo
attachment fetch author test1.txt -t author -r repo
attachment list author -t author -r repo
attachment delete author test1.txt -t author -r repo
attachment import author/manufacturer test1.txt -t manufacturer -r repo
attachment fetch author/manufacturer test1.txt -t manufacturer -r repo
attachment list author/manufacturer -t manufacturer -r repo
attachment delete author/manufacturer test1.txt -t manufacturer -r repo
```