### PR TITLE
API Documentation Fix on Exporting

### DIFF
--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -799,8 +799,8 @@ paths:
     get:
       tags:
         - repos
-      summary: Export the whole catalog
-      description: Export the whole catalog as a zip file
+      summary: Get exported catalog
+      description: Download the whole catalog as a zip file after a succesful export request
       operationId: getExportedCatalog
       responses:
         '200':
@@ -820,7 +820,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
-        - thing-models
+        - repos
       summary: Trigger exporting the whole catalog
       description: Trigger exporting the whole catalog as a zip file
       operationId: exportCatalog


### PR DESCRIPTION
Importing the API Doc again made me realize that the tags were wrong for getting the exported catalog. Also saw that the description can improve